### PR TITLE
Error types are now defined by an enum

### DIFF
--- a/product_code/authentication_service/impl/src/main/scala/de/upb/cs/uc4/authentication/impl/AuthenticationServiceImpl.scala
+++ b/product_code/authentication_service/impl/src/main/scala/de/upb/cs/uc4/authentication/impl/AuthenticationServiceImpl.scala
@@ -16,7 +16,7 @@ import de.upb.cs.uc4.authentication.impl.actor.{ AuthenticationEntry, Authentica
 import de.upb.cs.uc4.authentication.impl.commands.{ AuthenticationCommand, GetAuthentication, SetAuthentication }
 import de.upb.cs.uc4.authentication.impl.readside.AuthenticationEventProcessor
 import de.upb.cs.uc4.authentication.model.{ AuthenticationRole, AuthenticationUser, JsonUsername }
-import de.upb.cs.uc4.shared.client.exceptions.{ CustomException, DetailedError, SimpleError }
+import de.upb.cs.uc4.shared.client.exceptions.{ CustomException, DetailedError, SimpleError, ErrorType }
 import de.upb.cs.uc4.shared.server.Hashing
 import de.upb.cs.uc4.shared.server.ServiceCallFactory._
 import de.upb.cs.uc4.shared.server.messages.{ Accepted, Confirmation, RejectedWithError }
@@ -58,7 +58,7 @@ class AuthenticationServiceImpl(readSide: ReadSide, processor: AuthenticationEve
             throw CustomException.OwnerMismatch
           }
           if (role != user.role) {
-            throw new CustomException(422, DetailedError("uneditable fields", List(SimpleError("role", "Role may not be manually changed."))))
+            throw new CustomException(422, DetailedError(ErrorType.UneditableFields, List(SimpleError("role", "Role may not be manually changed."))))
           }
           val ref = entityRef(Hashing.sha256(user.username))
 

--- a/product_code/authentication_service/impl/src/main/scala/de/upb/cs/uc4/authentication/impl/actor/AuthenticationState.scala
+++ b/product_code/authentication_service/impl/src/main/scala/de/upb/cs/uc4/authentication/impl/actor/AuthenticationState.scala
@@ -5,7 +5,7 @@ import akka.persistence.typed.scaladsl.{ Effect, ReplyEffect }
 import de.upb.cs.uc4.authentication.impl.AuthenticationApplication
 import de.upb.cs.uc4.authentication.impl.commands.{ AuthenticationCommand, DeleteAuthentication, GetAuthentication, SetAuthentication }
 import de.upb.cs.uc4.authentication.impl.events.{ AuthenticationEvent, OnDelete, OnSet }
-import de.upb.cs.uc4.shared.client.exceptions.{ DetailedError, SimpleError }
+import de.upb.cs.uc4.shared.client.exceptions.{ DetailedError, SimpleError, ErrorType }
 import de.upb.cs.uc4.shared.server.Hashing
 import de.upb.cs.uc4.shared.server.messages.{ Accepted, Rejected, RejectedWithError }
 import play.api.libs.json.{ Format, Json }
@@ -28,7 +28,7 @@ case class AuthenticationState(optEntry: Option[AuthenticationEntry]) {
           Effect.persist(OnSet(user)).thenReply(replyTo) { _ => Accepted }
         }
         else {
-          Effect.reply(replyTo)(RejectedWithError(422, DetailedError("validation error", "Your request parameters did not validate", validationErrors)))
+          Effect.reply(replyTo)(RejectedWithError(422, DetailedError(ErrorType.Validation, "Your request parameters did not validate", validationErrors)))
         }
 
       case DeleteAuthentication(replyTo) => optEntry match {

--- a/product_code/course_service/impl/src/main/scala/de/upb/cs/uc4/course/impl/actor/CourseState.scala
+++ b/product_code/course_service/impl/src/main/scala/de/upb/cs/uc4/course/impl/actor/CourseState.scala
@@ -6,7 +6,7 @@ import de.upb.cs.uc4.course.impl.CourseApplication
 import de.upb.cs.uc4.course.impl.commands._
 import de.upb.cs.uc4.course.impl.events.{ CourseEvent, OnCourseCreate, OnCourseDelete, OnCourseUpdate }
 import de.upb.cs.uc4.course.model.Course
-import de.upb.cs.uc4.shared.client.exceptions.{ DetailedError, GenericError }
+import de.upb.cs.uc4.shared.client.exceptions.{ DetailedError, GenericError, ErrorType }
 import de.upb.cs.uc4.shared.server.messages.{ Accepted, Rejected, RejectedWithError }
 import play.api.libs.json.{ Format, Json }
 
@@ -28,11 +28,11 @@ case class CourseState(optCourse: Option[Course]) {
             Effect.persist(OnCourseCreate(course)).thenReply(replyTo) { _ => Accepted }
           }
           else {
-            Effect.reply(replyTo)(RejectedWithError(422, DetailedError("validation error", validationErrors)))
+            Effect.reply(replyTo)(RejectedWithError(422, DetailedError(ErrorType.Validation, validationErrors)))
           }
         }
         else {
-          Effect.reply(replyTo)(RejectedWithError(409, GenericError("key duplicate")))
+          Effect.reply(replyTo)(RejectedWithError(409, GenericError(ErrorType.KeyDuplicate)))
         }
 
       case UpdateCourse(courseRaw, replyTo) =>
@@ -44,11 +44,11 @@ case class CourseState(optCourse: Option[Course]) {
             Effect.persist(OnCourseUpdate(course)).thenReply(replyTo) { _ => Accepted }
           }
           else {
-            Effect.reply(replyTo)(RejectedWithError(422, DetailedError("validation error", validationErrors)))
+            Effect.reply(replyTo)(RejectedWithError(422, DetailedError(ErrorType.Validation, validationErrors)))
           }
         }
         else {
-          Effect.reply(replyTo)(RejectedWithError(404, GenericError("key not found")))
+          Effect.reply(replyTo)(RejectedWithError(404, GenericError(ErrorType.KeyDuplicate)))
         }
 
       case GetCourse(replyTo) =>

--- a/product_code/hyperledger_component/src/main/scala/de/upb/cs/uc4/hyperledger/HyperledgerUtils.scala
+++ b/product_code/hyperledger_component/src/main/scala/de/upb/cs/uc4/hyperledger/HyperledgerUtils.scala
@@ -24,17 +24,17 @@ object HyperledgerUtils {
   private def errorMatching(customError: CustomError): CustomException = {
     customError match {
       case genericError: GenericError => genericError.`type` match {
-        case "hl: unknown transactionId"      => new CustomException(500, genericError)
-        case "hl: unprocessable entity"       => new CustomException(422, genericError)
-        case "hl: not found"                  => new CustomException(404, genericError)
-        case "hl: conflict"                   => new CustomException(409, genericError)
-        case "hl: unprocessable ledger state" => new CustomException(500, genericError)
+        case ErrorType.HLUnknownTransactionId     => new CustomException(500, genericError)
+        case ErrorType.HLUnprocessableEntity      => new CustomException(422, genericError)
+        case ErrorType.HLNotFound                 => new CustomException(404, genericError)
+        case ErrorType.HLConflict                 => new CustomException(409, genericError)
+        case ErrorType.HLUnprocessableLedgerState => new CustomException(500, genericError)
       }
       case detailedError: DetailedError => detailedError.`type` match {
-        case "hl: unprocessable field" => new CustomException(422, detailedError)
+        case ErrorType.HLUnprocessableField => new CustomException(422, detailedError)
       }
       case transactionError: TransactionError => transactionError.`type` match {
-        case "hl: invalid transaction call" => new CustomException(500, transactionError)
+        case ErrorType.HLInvalidTransactionCall => new CustomException(500, transactionError)
       }
     }
   }

--- a/product_code/matriculation_service/impl/src/main/scala/de/upb/cs/uc4/matriculation/impl/MatriculationServiceImpl.scala
+++ b/product_code/matriculation_service/impl/src/main/scala/de/upb/cs/uc4/matriculation/impl/MatriculationServiceImpl.scala
@@ -14,7 +14,7 @@ import de.upb.cs.uc4.matriculation.api.MatriculationService
 import de.upb.cs.uc4.matriculation.impl.actor.MatriculationBehaviour
 import de.upb.cs.uc4.matriculation.impl.commands.{ AddEntryToMatriculationData, AddMatriculationData, GetMatriculationData }
 import de.upb.cs.uc4.matriculation.model.{ ImmatriculationData, PutMessageMatriculationData, SubjectMatriculation }
-import de.upb.cs.uc4.shared.client.exceptions.{ CustomException, DetailedError }
+import de.upb.cs.uc4.shared.client.exceptions.{ CustomException, DetailedError, ErrorType }
 import de.upb.cs.uc4.shared.server.ServiceCallFactory._
 import de.upb.cs.uc4.shared.server.messages.{ Accepted, Confirmation, RejectedWithError }
 import de.upb.cs.uc4.user.api.UserService
@@ -45,7 +45,7 @@ class MatriculationServiceImpl(clusterSharding: ClusterSharding, userService: Us
         val message = rawMessage.trim
         val validationList = message.validate
         if (validationList.nonEmpty) {
-          throw new CustomException(422, DetailedError("validation error", validationList))
+          throw new CustomException(422, DetailedError(ErrorType.Validation, validationList))
         }
         userService.getStudent(username).handleRequestHeader(addAuthenticationHeader(header)).invoke()
           .flatMap { student =>

--- a/product_code/matriculation_service/impl/src/test/scala/de/upb/cs/uc4/matriculation/impl/MatriculationServiceSpec.scala
+++ b/product_code/matriculation_service/impl/src/test/scala/de/upb/cs/uc4/matriculation/impl/MatriculationServiceSpec.scala
@@ -75,7 +75,7 @@ class MatriculationServiceSpec extends AsyncWordSpec with Matchers with BeforeAn
                   override val transactionId: String = "getMatriculationData"
                   override val payload: String =
                     """{
-                    |  "type": "hl: not found",
+                    |  "type": "HLNotFound",
                     |  "title": "There is no MatriculationData for the given matriculationId."
                     |}""".stripMargin
                 }

--- a/product_code/shared/client/src/main/scala/de/upb/cs/uc4/shared/client/exceptions/CustomError.scala
+++ b/product_code/shared/client/src/main/scala/de/upb/cs/uc4/shared/client/exceptions/CustomError.scala
@@ -1,9 +1,10 @@
 package de.upb.cs.uc4.shared.client.exceptions
 
+import de.upb.cs.uc4.shared.client.exceptions.ErrorType.ErrorType
 import play.api.libs.json.{ Format, JsResult, JsValue, Json }
 
 trait CustomError {
-  val `type`: String
+  val `type`: ErrorType
   val title: String
 
 }
@@ -22,45 +23,6 @@ object CustomError {
       case gErr: GenericError     => Json.toJson(gErr)
       case tErr: TransactionError => Json.toJson(tErr)
       case iErr: InformativeError => Json.toJson(iErr)
-    }
-  }
-
-  def getTitle(`type`: String): String = {
-    `type` match {
-      //HL errors are missing, but as they are given to us with a title, we do not need to find a fitting title
-      //If not stated otherwise, the type is contained in a  GenericError
-      //400
-      case "deserialization error" => "Syntax of the provided json object was incorrect"
-      case "json validation error" => "The provided json object did not validate"
-      case "malformed refresh token" => "The long term token is malformed"
-      case "malformed login token" => "The login token is malformed"
-      //401
-      case "basic authorization error" => "Username and password combination does not exist"
-      case "jwt authorization error" => "Authorization token missing"
-      case "refresh token expired" => "Your long term session expired"
-      case "login token expired" => "Your session expired"
-      //403
-      case "not enough privileges" => "Insufficient privileges for this action"
-      case "owner mismatch" => "You are not allowed to modify the resource"
-      //404
-      case "key not found" => "Key value is not in use"
-      //409
-      case "key duplicate" => "Key is already in use"
-      //418
-      case "teapot" => "I'm a teapot"
-      //422
-      case "path parameter mismatch" => "Parameter specified in path and in object do not match"
-      case "validation error" => "Your request parameters did not validate" //In a DetailedError
-      case "uneditable fields" => "Attempted to change uneditable fields" //In a DetailedError
-      case "refresh token signature invalid" => "The long term token has a wrong signature"
-      case "login token signature invalid" => "The login term token has a wrong signature"
-      //500
-      case "internal server error" => "An internal server error has occurred"
-      case "undeserializable exception" => "Internal error while deserializing Exception"
-      case "hl: internal error" => "Hyperledger encountered an internal error" //In an InformativeError
-      //???
-      case _ => "Title not Found"
-
     }
   }
 }

--- a/product_code/shared/client/src/main/scala/de/upb/cs/uc4/shared/client/exceptions/CustomException.scala
+++ b/product_code/shared/client/src/main/scala/de/upb/cs/uc4/shared/client/exceptions/CustomException.scala
@@ -20,26 +20,26 @@ class CustomException(errorCode: TransportErrorCode, possibleErrorResponse: Cust
 }
 object CustomException {
   //400
-  val DeserializationError = new CustomException(400, GenericError("deserialization error"))
-  val MalformedRefreshToken = new CustomException(400, GenericError("malformed refresh token"))
-  val MalformedLoginToken = new CustomException(400, GenericError("malformed login token"))
+  val DeserializationError = new CustomException(400, GenericError(ErrorType.Deserialization))
+  val MalformedRefreshToken = new CustomException(400, GenericError(ErrorType.MalformedRefreshToken))
+  val MalformedLoginToken = new CustomException(400, GenericError(ErrorType.MalformedLoginToken))
   //401
-  val AuthorizationError = new CustomException(401, GenericError("jwt authorization error"))
-  val BasicAuthorizationError = new CustomException(401, GenericError("basic authorization error"))
-  val RefreshTokenExpired = new CustomException(401, GenericError("refresh token expired"))
-  val LoginTokenExpired = new CustomException(401, GenericError("login token expired"))
+  val AuthorizationError = new CustomException(401, GenericError(ErrorType.JwtAuthorization))
+  val BasicAuthorizationError = new CustomException(401, GenericError(ErrorType.BasicAuthorization))
+  val RefreshTokenExpired = new CustomException(401, GenericError(ErrorType.RefreshTokenExpired))
+  val LoginTokenExpired = new CustomException(401, GenericError(ErrorType.LoginTokenExpired))
   //403
-  val NotEnoughPrivileges = new CustomException(403, GenericError("not enough privileges"))
-  val OwnerMismatch = new CustomException(403, GenericError("owner mismatch"))
+  val NotEnoughPrivileges = new CustomException(403, GenericError(ErrorType.NotEnoughPrivileges))
+  val OwnerMismatch = new CustomException(403, GenericError(ErrorType.OwnerMismatch))
   //404
-  val NotFound = new CustomException(404, GenericError("key not found"))
+  val NotFound = new CustomException(404, GenericError(ErrorType.KeyNotFound))
   //409
-  val Duplicate = new CustomException(409, GenericError("key duplicate"))
+  val Duplicate = new CustomException(409, GenericError(ErrorType.KeyDuplicate))
   //422
-  val PathParameterMismatch = new CustomException(422, GenericError("path parameter mismatch"))
-  val RefreshTokenSignatureError = new CustomException(422, GenericError("refresh token signature invalid"))
-  val LoginTokenSignatureError = new CustomException(422, GenericError("login token signature invalid"))
+  val PathParameterMismatch = new CustomException(422, GenericError(ErrorType.PathParameterMismatch))
+  val RefreshTokenSignatureError = new CustomException(422, GenericError(ErrorType.RefreshTokenSignatureInvalid))
+  val LoginTokenSignatureError = new CustomException(422, GenericError(ErrorType.LoginTokenSignatureInvalid))
   //500
-  val InternalServerError = new CustomException(500, GenericError("internal server error"))
-  val InternalDeserializationError = new CustomException(500, GenericError("undeserializable exception"))
+  val InternalServerError = new CustomException(500, GenericError(ErrorType.InternalServer))
+  val InternalDeserializationError = new CustomException(500, GenericError(ErrorType.UndeserializableException))
 }

--- a/product_code/shared/client/src/main/scala/de/upb/cs/uc4/shared/client/exceptions/DetailedError.scala
+++ b/product_code/shared/client/src/main/scala/de/upb/cs/uc4/shared/client/exceptions/DetailedError.scala
@@ -1,14 +1,15 @@
 package de.upb.cs.uc4.shared.client.exceptions
 
+import de.upb.cs.uc4.shared.client.exceptions.ErrorType.ErrorType
 import play.api.libs.json._
 
-case class DetailedError(`type`: String, title: String, invalidParams: Seq[SimpleError]) extends CustomError
+case class DetailedError(`type`: ErrorType, title: String, invalidParams: Seq[SimpleError]) extends CustomError
 
 object DetailedError {
   implicit val format: Format[DetailedError] = Json.format
 
-  def apply(`type`: String, invalidParams: Seq[SimpleError]): DetailedError = {
-    val title = CustomError.getTitle(`type`)
+  def apply(`type`: ErrorType, invalidParams: Seq[SimpleError]): DetailedError = {
+    val title = ErrorType.getTitle(`type`)
     new DetailedError(`type`, title, invalidParams)
   }
 }

--- a/product_code/shared/client/src/main/scala/de/upb/cs/uc4/shared/client/exceptions/ErrorType.scala
+++ b/product_code/shared/client/src/main/scala/de/upb/cs/uc4/shared/client/exceptions/ErrorType.scala
@@ -1,0 +1,63 @@
+package de.upb.cs.uc4.shared.client.exceptions
+
+import play.api.libs.json.{ Format, Json }
+
+object ErrorType extends Enumeration {
+  type ErrorType = Value
+  val Deserialization, JsonValidation, MalformedRefreshToken, MalformedLoginToken, UnexpectedEntity, //400
+  BasicAuthorization, JwtAuthorization, RefreshTokenExpired, LoginTokenExpired, //401
+  NotEnoughPrivileges, OwnerMismatch, //403
+  KeyNotFound, //404
+  KeyDuplicate, //409
+  Teapot, //418
+  PathParameterMismatch, RefreshTokenSignatureInvalid, LoginTokenSignatureInvalid, //422
+  Validation, UneditableFields, //422 In a DetailedError
+  InternalServer, UndeserializableException, //500
+  HLInternal, //500 In an InformativeError
+  HLUnknownTransactionId, HLUnprocessableEntity, HLNotFound, HLConflict, HLUnprocessableLedgerState, //In a GenericError
+  HLUnprocessableField, //In a DetailedError
+  HLInvalidTransactionCall //In a TransactionError
+  = Value
+
+  implicit val format: Format[ErrorType] = Json.formatEnum(this)
+
+  def All: Seq[ErrorType] = values.toSeq
+
+  def getTitle(errorType: ErrorType): String = {
+    errorType match {
+      //HL errors are missing, but as they are given to us with a title, we do not need to find a fitting title
+      //If not stated otherwise, the type is contained in a  GenericError
+      //400
+      case Deserialization => "Syntax of the provided json object was incorrect"
+      case JsonValidation => "The provided json object did not validate"
+      case MalformedRefreshToken => "The long term token is malformed"
+      case MalformedLoginToken => "The login token is malformed"
+      case UnexpectedEntity => "Expected another entity"
+      //401
+      case BasicAuthorization => "Username and password combination does not exist"
+      case JwtAuthorization => "Authorization token missing"
+      case RefreshTokenExpired => "Your long term session expired"
+      case LoginTokenExpired => "Your session expired"
+      //403
+      case NotEnoughPrivileges => "Insufficient privileges for this action"
+      case OwnerMismatch => "You are not allowed to modify the resource"
+      //404
+      case KeyNotFound => "Key value is not in use"
+      //409
+      case KeyDuplicate => "Key is already in use"
+      //418
+      case Teapot => "I'm a teapot"
+      //422
+      case PathParameterMismatch => "Parameter specified in path and in object do not match"
+      case Validation => "Your request parameters did not validate" //In a DetailedError
+      case UneditableFields => "Attempted to change uneditable fields" //In a DetailedError
+      case RefreshTokenSignatureInvalid => "The long term token has a wrong signature"
+      case LoginTokenSignatureInvalid => "The login term token has a wrong signature"
+      //500
+      case InternalServer => "An internal server error has occurred"
+      case UndeserializableException => "Internal error while deserializing Exception"
+      case HLInternal => "Hyperledger encountered an internal error" //In an InformativeError
+    }
+  }
+
+}

--- a/product_code/shared/client/src/main/scala/de/upb/cs/uc4/shared/client/exceptions/GenericError.scala
+++ b/product_code/shared/client/src/main/scala/de/upb/cs/uc4/shared/client/exceptions/GenericError.scala
@@ -1,14 +1,15 @@
 package de.upb.cs.uc4.shared.client.exceptions
 
+import de.upb.cs.uc4.shared.client.exceptions.ErrorType.ErrorType
 import play.api.libs.json._
 
-case class GenericError(`type`: String, title: String) extends CustomError
+case class GenericError(`type`: ErrorType, title: String) extends CustomError
 
 object GenericError {
   implicit val format: Format[GenericError] = Json.format
 
-  def apply(`type`: String): GenericError = {
-    val title = CustomError.getTitle(`type`)
+  def apply(`type`: ErrorType): GenericError = {
+    val title = ErrorType.getTitle(`type`)
     new GenericError(`type`, title)
   }
 }

--- a/product_code/shared/client/src/main/scala/de/upb/cs/uc4/shared/client/exceptions/InformativeError.scala
+++ b/product_code/shared/client/src/main/scala/de/upb/cs/uc4/shared/client/exceptions/InformativeError.scala
@@ -1,14 +1,15 @@
 package de.upb.cs.uc4.shared.client.exceptions
 
+import de.upb.cs.uc4.shared.client.exceptions.ErrorType.ErrorType
 import play.api.libs.json.{ Format, Json }
 
-case class InformativeError(`type`: String, title: String, information: String) extends CustomError
+case class InformativeError(`type`: ErrorType, title: String, information: String) extends CustomError
 
 object InformativeError {
   implicit val format: Format[InformativeError] = Json.format
 
-  def apply(`type`: String, information: String): InformativeError = {
-    val title = CustomError.getTitle(`type`)
+  def apply(`type`: ErrorType, information: String): InformativeError = {
+    val title = ErrorType.getTitle(`type`)
     new InformativeError(`type`, title, information)
   }
 }

--- a/product_code/shared/client/src/main/scala/de/upb/cs/uc4/shared/client/exceptions/TransactionError.scala
+++ b/product_code/shared/client/src/main/scala/de/upb/cs/uc4/shared/client/exceptions/TransactionError.scala
@@ -1,14 +1,15 @@
 package de.upb.cs.uc4.shared.client.exceptions
 
+import de.upb.cs.uc4.shared.client.exceptions.ErrorType.ErrorType
 import play.api.libs.json._
 
-case class TransactionError(`type`: String, title: String, transactionId: String) extends CustomError
+case class TransactionError(`type`: ErrorType, title: String, transactionId: String) extends CustomError
 
 object TransactionError {
   implicit val format: Format[TransactionError] = Json.format
 
-  def apply(`type`: String, transactionId: String): TransactionError = {
-    val title = CustomError.getTitle(`type`)
+  def apply(`type`: ErrorType, transactionId: String): TransactionError = {
+    val title = ErrorType.getTitle(`type`)
     new TransactionError(`type`, title, transactionId)
   }
 }

--- a/product_code/shared/client/src/main/scala/de/upb/cs/uc4/shared/client/message_serialization/CustomMessageSerializer.scala
+++ b/product_code/shared/client/src/main/scala/de/upb/cs/uc4/shared/client/message_serialization/CustomMessageSerializer.scala
@@ -4,7 +4,7 @@ import akka.util.ByteString
 import com.lightbend.lagom.scaladsl.api.deser.MessageSerializer.{ NegotiatedDeserializer, NegotiatedSerializer }
 import com.lightbend.lagom.scaladsl.api.deser.{ MessageSerializer, StrictMessageSerializer }
 import com.lightbend.lagom.scaladsl.api.transport.{ DeserializationException, MessageProtocol, SerializationException }
-import de.upb.cs.uc4.shared.client.exceptions.{ CustomException, SimpleError }
+import de.upb.cs.uc4.shared.client.exceptions.{ CustomException, SimpleError, ErrorType }
 import de.upb.cs.uc4.shared.client.exceptions
 import play.api.libs.json._
 
@@ -62,7 +62,7 @@ object CustomMessageSerializer {
                   list.head.message.replaceFirst("error.", "")
                 )
             }.toList
-            throw new CustomException(400, exceptions.DetailedError("json validation error", errorList))
+            throw new CustomException(400, exceptions.DetailedError(ErrorType.JsonValidation, errorList))
         }
       }
     }

--- a/product_code/user_service/impl/src/main/scala/de/upb/cs/uc4/user/impl/actor/UserState.scala
+++ b/product_code/user_service/impl/src/main/scala/de/upb/cs/uc4/user/impl/actor/UserState.scala
@@ -2,7 +2,7 @@ package de.upb.cs.uc4.user.impl.actor
 
 import akka.cluster.sharding.typed.scaladsl.EntityTypeKey
 import akka.persistence.typed.scaladsl.{ Effect, ReplyEffect }
-import de.upb.cs.uc4.shared.client.exceptions.{ DetailedError, GenericError, SimpleError }
+import de.upb.cs.uc4.shared.client.exceptions.{ DetailedError, GenericError, SimpleError, ErrorType }
 import de.upb.cs.uc4.shared.server.messages._
 import de.upb.cs.uc4.user.impl.UserApplication
 import de.upb.cs.uc4.user.impl.commands._
@@ -46,11 +46,11 @@ case class UserState(optUser: Option[User]) {
             Effect.persist(OnUserCreate(trimmedUser)).thenReply(replyTo) { _ => Accepted }
           }
           else {
-            Effect.reply(replyTo)(RejectedWithError(422, DetailedError("validation error", "Your request parameters did not validate", validationErrors)))
+            Effect.reply(replyTo)(RejectedWithError(422, DetailedError(ErrorType.Validation, "Your request parameters did not validate", validationErrors)))
           }
         }
         else {
-          Effect.reply(replyTo)(RejectedWithError(409, GenericError("key value error", "Username is already taken")))
+          Effect.reply(replyTo)(RejectedWithError(409, GenericError(ErrorType.KeyDuplicate, "Username is already taken")))
         }
 
       case UpdateUser(user, replyTo) =>
@@ -62,11 +62,11 @@ case class UserState(optUser: Option[User]) {
             Effect.persist(OnUserUpdate(trimmedUser)).thenReply(replyTo) { _ => Accepted }
           }
           else {
-            Effect.reply(replyTo)(RejectedWithError(422, DetailedError("validation error", "Your request parameters did not validate", validationErrors)))
+            Effect.reply(replyTo)(RejectedWithError(422, DetailedError(ErrorType.Validation, "Your request parameters did not validate", validationErrors)))
           }
         }
         else {
-          Effect.reply(replyTo)(RejectedWithError(404, GenericError("key value error", "Username not found")))
+          Effect.reply(replyTo)(RejectedWithError(404, GenericError(ErrorType.KeyNotFound, "Username not found")))
         }
 
       case UpdateLatestMatriculation(semester, replyTo) =>
@@ -80,7 +80,7 @@ case class UserState(optUser: Option[User]) {
           }
         }
         else {
-          Effect.reply(replyTo)(RejectedWithError(500, GenericError("internal server error")))
+          Effect.reply(replyTo)(RejectedWithError(500, GenericError(ErrorType.InternalServer)))
         }
 
       case DeleteUser(replyTo) =>

--- a/product_code/user_service/impl/src/main/scala/de/upb/cs/uc4/user/impl/actor/UserState.scala
+++ b/product_code/user_service/impl/src/main/scala/de/upb/cs/uc4/user/impl/actor/UserState.scala
@@ -3,7 +3,7 @@ package de.upb.cs.uc4.user.impl.actor
 import akka.cluster.sharding.typed.scaladsl.EntityTypeKey
 import akka.persistence.typed.scaladsl.{ Effect, ReplyEffect }
 import de.upb.cs.uc4.shared.client.Utils.SemesterUtils
-import de.upb.cs.uc4.shared.client.exceptions.GenericError
+import de.upb.cs.uc4.shared.client.exceptions.{ ErrorType, GenericError }
 import de.upb.cs.uc4.shared.server.messages._
 import de.upb.cs.uc4.user.impl.UserApplication
 import de.upb.cs.uc4.user.impl.commands._


### PR DESCRIPTION
### Reason for this PR
- Using strings as type key is error prone.

### Changes in this PR
- All Exception now use the `ErrorType` enum as type key.
