### PR TITLE
Adapt CourseServiceSpec to include the correct cleanup

### DIFF
--- a/product_code/course_service/impl/src/test/scala/de/upb/cs/uc4/course/impl/CourseServiceSpec.scala
+++ b/product_code/course_service/impl/src/test/scala/de/upb/cs/uc4/course/impl/CourseServiceSpec.scala
@@ -91,16 +91,16 @@ class CourseServiceSpec extends AsyncWordSpec with Matchers with BeforeAndAfterA
     }
   }
 
-  def cleanupOnFailure(): PartialFunction[Throwable, Future[Assertion]] = PartialFunction.fromFunction { x =>
+  def cleanupOnFailure(): PartialFunction[Throwable, Future[Assertion]] = PartialFunction.fromFunction { throwable =>
     deleteAllCourses()
       .map { _ =>
-        throw x
+        throw throwable
       }
   }
-  def cleanupOnSuccess(value: Assertion): Future[Assertion] = {
+  def cleanupOnSuccess(assertion: Assertion): Future[Assertion] = {
     deleteAllCourses()
       .map { _ =>
-        value
+        assertion
       }
   }
 

--- a/product_code/course_service/impl/src/test/scala/de/upb/cs/uc4/course/impl/CourseServiceSpec.scala
+++ b/product_code/course_service/impl/src/test/scala/de/upb/cs/uc4/course/impl/CourseServiceSpec.scala
@@ -2,7 +2,6 @@ package de.upb.cs.uc4.course.impl
 
 import java.util.Calendar
 
-import akka.Done
 import com.lightbend.lagom.scaladsl.api.transport.RequestHeader
 import com.lightbend.lagom.scaladsl.server.LocalServiceLocator
 import com.lightbend.lagom.scaladsl.testkit.ServiceTest
@@ -13,7 +12,6 @@ import de.upb.cs.uc4.course.model.{ Course, CourseLanguage, CourseType }
 import de.upb.cs.uc4.shared.client.exceptions.CustomException
 import io.jsonwebtoken.{ Jwts, SignatureAlgorithm }
 import org.scalatest.concurrent.Eventually
-import org.scalatest.events.TestFailed
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{ Seconds, Span }
 import org.scalatest.wordspec.AsyncWordSpec
@@ -21,7 +19,6 @@ import org.scalatest.{ Assertion, BeforeAndAfterAll }
 
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, Future }
-import scala.util.{ Failure, Success, Try }
 
 /** Tests for the CourseService
   * All tests need to be started in the defined order
@@ -76,30 +73,32 @@ class CourseServiceSpec extends AsyncWordSpec with Matchers with BeforeAndAfterA
   }
 
   def deleteAllCourses(): Future[Assertion] = {
-    server.application.database.getAll.map(
-      _.map { courseId =>
-        val result = Await.result(client.deleteCourse(courseId).handleRequestHeader(addAuthorizationHeader()).invoke(), 5.seconds)
-        assert(result == Done)
-        result
+    client.getAllCourses(None, None).handleRequestHeader(addAuthorizationHeader()).invoke().map {
+      _.map { course =>
+        Await.result(client.deleteCourse(course.courseId).handleRequestHeader(addAuthorizationHeader()).invoke(), 5.seconds)
       }
-    ).flatMap { _ =>
-        eventually(timeout(Span(15, Seconds))) {
-          for {
-            courseNames <- server.application.database.getAll
-          } yield {
-            courseNames shouldBe empty
-          }
+    }.flatMap { _ =>
+      eventually(timeout(Span(15, Seconds))) {
+        for {
+          courseNames <- server.application.database.getAll
+        } yield {
+          courseNames shouldBe empty
         }
       }
+    }
   }
 
-  def cleanup[A](): PartialFunction[Try[A], Future[A]] = PartialFunction.fromFunction {
-    case Success(value) => deleteAllCourses().map { _ =>
-      value
-    }
-    case Failure(throwable) => deleteAllCourses().map { _ =>
-      throw throwable
-    }
+  def cleanupOnFailure(): PartialFunction[Throwable, Future[Assertion]] = PartialFunction.fromFunction { x =>
+    deleteAllCourses()
+      .map { _ =>
+        throw x
+      }
+  }
+  def cleanupOnSuccess(value: Assertion): Future[Assertion] = {
+    deleteAllCourses()
+      .map { _ =>
+        value
+      }
   }
 
   /** Tests only working if the whole instance is started */
@@ -108,7 +107,8 @@ class CourseServiceSpec extends AsyncWordSpec with Matchers with BeforeAndAfterA
     "get all courses with no courses" in {
       client.getAllCourses(None, None).handleRequestHeader(addAuthorizationHeader()).invoke().map { answer =>
         answer shouldBe empty
-      }
+      }.flatMap(cleanupOnSuccess)
+        .recoverWith(cleanupOnFailure())
     }
 
     "create a course" in {
@@ -118,32 +118,36 @@ class CourseServiceSpec extends AsyncWordSpec with Matchers with BeforeAndAfterA
           client.getAllCourses(None, None).handleRequestHeader(addAuthorizationHeader()).invoke().map { answer =>
             answer should contain theSameElementsAs Seq(createdCourse)
           }
-        }.andThen(cleanup())
-      }
+        }
+      }.flatMap(cleanupOnSuccess)
+        .recoverWith(cleanupOnFailure())
     }
 
     "get all courses with matching names" in {
-      prepare(Seq(course0, course1, course2)).flatMap { createdCourses =>
+      prepare(Seq(course0, course1, course2)).flatMap { _ =>
         client.getAllCourses(Some("Course 1"), None).handleRequestHeader(addAuthorizationHeader()).invoke().map { answer =>
           answer.map(_.copy(courseId = "")) should contain theSameElementsAs Seq(course1, course2)
-        }.andThen(cleanup())
-      }
+        }
+      }.flatMap(cleanupOnSuccess)
+        .recoverWith(cleanupOnFailure())
     }
 
     "get all courses with matching lecturerIds" in {
-      prepare(Seq(course0, course1, course2)).flatMap { createdCourses =>
+      prepare(Seq(course0, course1, course2)).flatMap { _ =>
         client.getAllCourses(None, Some("11")).handleRequestHeader(addAuthorizationHeader()).invoke().map { answer =>
           answer.map(_.copy(courseId = "")) should contain theSameElementsAs Seq(course0, course1)
-        }.andThen(cleanup())
-      }
+        }
+      }.flatMap(cleanupOnSuccess)
+        .recoverWith(cleanupOnFailure())
     }
 
     "get all courses with matching names and lecturerIds" in {
-      prepare(Seq(course0, course1, course2)).flatMap { createdCourses =>
+      prepare(Seq(course0, course1, course2)).flatMap { _ =>
         client.getAllCourses(Some("Course 1"), Some("11")).handleRequestHeader(addAuthorizationHeader()).invoke().map { answer =>
           answer.map(_.copy(courseId = "")) should contain theSameElementsAs Seq(course1)
-        }.andThen(cleanup())
-      }
+        }
+      }.flatMap(cleanupOnSuccess)
+        .recoverWith(cleanupOnFailure())
     }
 
     "delete a non-existing course" in {
@@ -162,8 +166,9 @@ class CourseServiceSpec extends AsyncWordSpec with Matchers with BeforeAndAfterA
               answer should not contain createdCourses.head
             }
           }
-        }.andThen(cleanup())
-      }
+        }
+      }.flatMap(cleanupOnSuccess)
+        .recoverWith(cleanupOnFailure())
     }
 
     "find a non-existing course" in {
@@ -176,8 +181,9 @@ class CourseServiceSpec extends AsyncWordSpec with Matchers with BeforeAndAfterA
       prepare(Seq(course1)).flatMap { createdCourses =>
         client.findCourseByCourseId(createdCourses.head.courseId).handleRequestHeader(addAuthorizationHeader()).invoke().map { answer =>
           answer should ===(createdCourses.head)
-        }.andThen(cleanup())
-      }
+        }
+      }.flatMap(cleanupOnSuccess)
+        .recoverWith(cleanupOnFailure())
     }
 
     "update a non-existing course" in {
@@ -195,9 +201,10 @@ class CourseServiceSpec extends AsyncWordSpec with Matchers with BeforeAndAfterA
             client.findCourseByCourseId(course4.courseId).handleRequestHeader(addAuthorizationHeader()).invoke().map { answer =>
               answer should ===(course4)
             }
-          }.andThen(cleanup())
+          }
         }
-      }
+      }.flatMap(cleanupOnSuccess)
+        .recoverWith(cleanupOnFailure())
     }
 
   }


### PR DESCRIPTION
### Reason for this PR
- In UserServiceSpec, we adapted the cleanup to be properly waited for before starting the next test

### Changes in this PR
- Change cleanup in CourseServiceSpec to reliably run completely before starting the next test
- Closes #252 
