### PR TITLE
Fix minor errors regarding error types

### DIFF
--- a/product_code/shared/client/src/main/scala/de/upb/cs/uc4/shared/client/exceptions/CustomException.scala
+++ b/product_code/shared/client/src/main/scala/de/upb/cs/uc4/shared/client/exceptions/CustomException.scala
@@ -21,7 +21,6 @@ class CustomException(errorCode: TransportErrorCode, possibleErrorResponse: Cust
 object CustomException {
   //400
   val DeserializationError = new CustomException(400, GenericError(ErrorType.Deserialization))
-  val WrongObject = new CustomException(400, GenericError(ErrorType.UnexpectedEntity))
   val MalformedRefreshToken = new CustomException(400, GenericError(ErrorType.MalformedRefreshToken))
   val MalformedLoginToken = new CustomException(400, GenericError(ErrorType.MalformedLoginToken))
   //401

--- a/product_code/shared/client/src/main/scala/de/upb/cs/uc4/shared/client/exceptions/ErrorType.scala
+++ b/product_code/shared/client/src/main/scala/de/upb/cs/uc4/shared/client/exceptions/ErrorType.scala
@@ -29,10 +29,10 @@ object ErrorType extends Enumeration {
       //If not stated otherwise, the type is contained in a  GenericError
       //400
       case Deserialization => "Syntax of the provided json object was incorrect"
-      case JsonValidation => "The provided json object did not validate"
+      case JsonValidation => "The provided json object did not validate"  //In a DetailedError
       case MalformedRefreshToken => "The long term token is malformed"
       case MalformedLoginToken => "The login token is malformed"
-      case UnexpectedEntity => "Expected another entity"
+      case UnexpectedEntity => "Expected another entity"  //In an InformativeError
       //401
       case BasicAuthorization => "Username and password combination does not exist"
       case JwtAuthorization => "Authorization token missing"

--- a/product_code/shared/client/src/main/scala/de/upb/cs/uc4/shared/client/exceptions/ErrorType.scala
+++ b/product_code/shared/client/src/main/scala/de/upb/cs/uc4/shared/client/exceptions/ErrorType.scala
@@ -29,10 +29,10 @@ object ErrorType extends Enumeration {
       //If not stated otherwise, the type is contained in a  GenericError
       //400
       case Deserialization => "Syntax of the provided json object was incorrect"
-      case JsonValidation => "The provided json object did not validate"  //In a DetailedError
+      case JsonValidation => "The provided json object did not validate" //In a DetailedError
       case MalformedRefreshToken => "The long term token is malformed"
       case MalformedLoginToken => "The login token is malformed"
-      case UnexpectedEntity => "Expected another entity"  //In an InformativeError
+      case UnexpectedEntity => "Expected another entity" //In an InformativeError
       //401
       case BasicAuthorization => "Username and password combination does not exist"
       case JwtAuthorization => "Authorization token missing"


### PR DESCRIPTION
### Reason for this PR
- Small corrections had to be made when reviewing the Error types in the api

### Changes in this PR
- Changed WrongObject/UnexpectedEntity to only be an Informative Error, instead of Generic and Informative
- Add comments to reflect the Error Object for the ErrorTypes
