### PR TITLE
Refactor/authentication tests

### DIFF
--- a/product_code/authentication_service/CHANGELOG.md
+++ b/product_code/authentication_service/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [v.0.9.0-WIP](https://github.com/upb-uc4/University-Credits-4.0/compare/authentication-v0.8.2...authentication-v0.9.0) (2020-XX-XX)
+## Feature
+## Refactor
+ - Authentication Tests are now Unit-Tests
+## Bugfix
+
+
 # [v.0.8.2](https://github.com/upb-uc4/University-Credits-4.0/compare/authentication-v0.8.1...authentication-v0.8.2) (2020-09-22)
 ## Feature
  - Added Gzipping in Options Header

--- a/product_code/authentication_service/CHANGELOG.md
+++ b/product_code/authentication_service/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Refactor
  - Authentication Tests are now Unit-Tests
 ## Bugfix
+ - Fixed bug that prevented authentication users being deleted from the tables
+ - Fixed bug that lead to a wrong error being shown when the refresh token was missing for machine users
 
 
 # [v.0.8.2](https://github.com/upb-uc4/University-Credits-4.0/compare/authentication-v0.8.1...authentication-v0.8.2) (2020-09-22)

--- a/product_code/authentication_service/impl/src/main/scala/de/upb/cs/uc4/authentication/impl/AuthenticationServiceImpl.scala
+++ b/product_code/authentication_service/impl/src/main/scala/de/upb/cs/uc4/authentication/impl/AuthenticationServiceImpl.scala
@@ -1,33 +1,33 @@
 package de.upb.cs.uc4.authentication.impl
 
 import java.text.SimpleDateFormat
-import java.util.{Base64, Calendar, Locale, TimeZone}
+import java.util.{ Base64, Calendar, Locale, TimeZone }
 
-import akka.cluster.sharding.typed.scaladsl.{ClusterSharding, EntityRef}
+import akka.cluster.sharding.typed.scaladsl.{ ClusterSharding, EntityRef }
 import akka.util.Timeout
-import akka.{Done, NotUsed}
+import akka.{ Done, NotUsed }
 import com.lightbend.lagom.scaladsl.api.ServiceCall
 import com.lightbend.lagom.scaladsl.api.transport._
 import com.lightbend.lagom.scaladsl.persistence.ReadSide
 import com.lightbend.lagom.scaladsl.server.ServerServiceCall
 import com.typesafe.config.Config
 import de.upb.cs.uc4.authentication.api.AuthenticationService
-import de.upb.cs.uc4.authentication.impl.actor.{AuthenticationEntry, AuthenticationState}
-import de.upb.cs.uc4.authentication.impl.commands.{AuthenticationCommand, GetAuthentication, SetAuthentication}
+import de.upb.cs.uc4.authentication.impl.actor.{ AuthenticationEntry, AuthenticationState }
+import de.upb.cs.uc4.authentication.impl.commands.{ AuthenticationCommand, GetAuthentication, SetAuthentication }
 import de.upb.cs.uc4.authentication.impl.readside.AuthenticationEventProcessor
 import de.upb.cs.uc4.authentication.model.AuthenticationRole.AuthenticationRole
-import de.upb.cs.uc4.authentication.model.{AuthenticationRole, AuthenticationUser, JsonUsername, RefreshToken, Tokens}
-import de.upb.cs.uc4.shared.client.exceptions.{CustomException, DetailedError, ErrorType, SimpleError}
+import de.upb.cs.uc4.authentication.model.{ AuthenticationRole, AuthenticationUser, JsonUsername, RefreshToken, Tokens }
+import de.upb.cs.uc4.shared.client.exceptions.{ CustomException, DetailedError, ErrorType, SimpleError }
 import de.upb.cs.uc4.shared.server.Hashing
 import de.upb.cs.uc4.shared.server.ServiceCallFactory._
-import de.upb.cs.uc4.shared.server.messages.{Accepted, Confirmation, RejectedWithError}
+import de.upb.cs.uc4.shared.server.messages.{ Accepted, Confirmation, RejectedWithError }
 import io.jsonwebtoken._
 
 import scala.concurrent.duration._
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ ExecutionContext, Future }
 
 class AuthenticationServiceImpl(readSide: ReadSide, processor: AuthenticationEventProcessor,
-                                clusterSharding: ClusterSharding, config: Config)(implicit ec: ExecutionContext) extends AuthenticationService {
+    clusterSharding: ClusterSharding, config: Config)(implicit ec: ExecutionContext) extends AuthenticationService {
 
   readSide.register(processor)
 
@@ -180,7 +180,7 @@ class AuthenticationServiceImpl(readSide: ReadSide, processor: AuthenticationEve
       case Array("Basic", userAndPass) =>
         new String(Base64.getDecoder.decode(userAndPass), "UTF-8").split(":") match {
           case Array(user, password) => Option(user, password)
-          case _ => None
+          case _                     => None
         }
       case _ => None
     }
@@ -294,13 +294,13 @@ class AuthenticationServiceImpl(readSide: ReadSide, processor: AuthenticationEve
       (loginToken, logoutTimer * 60, username)
     }
     catch {
-      case _: ExpiredJwtException => throw CustomException.RefreshTokenExpired
-      case _: UnsupportedJwtException => throw CustomException.MalformedRefreshToken
-      case _: MalformedJwtException => throw CustomException.MalformedRefreshToken
-      case _: SignatureException => throw CustomException.RefreshTokenSignatureError
+      case _: ExpiredJwtException      => throw CustomException.RefreshTokenExpired
+      case _: UnsupportedJwtException  => throw CustomException.MalformedRefreshToken
+      case _: MalformedJwtException    => throw CustomException.MalformedRefreshToken
+      case _: SignatureException       => throw CustomException.RefreshTokenSignatureError
       case _: IllegalArgumentException => throw CustomException.RefreshTokenMissing
-      case ce: CustomException => throw ce
-      case _: Throwable => throw CustomException.InternalServerError
+      case ce: CustomException         => throw ce
+      case _: Throwable                => throw CustomException.InternalServerError
     }
   }
 }

--- a/product_code/authentication_service/impl/src/main/scala/de/upb/cs/uc4/authentication/impl/AuthenticationServiceImpl.scala
+++ b/product_code/authentication_service/impl/src/main/scala/de/upb/cs/uc4/authentication/impl/AuthenticationServiceImpl.scala
@@ -1,33 +1,33 @@
 package de.upb.cs.uc4.authentication.impl
 
 import java.text.SimpleDateFormat
-import java.util.{ Base64, Calendar, Locale, TimeZone }
+import java.util.{Base64, Calendar, Locale, TimeZone}
 
-import akka.cluster.sharding.typed.scaladsl.{ ClusterSharding, EntityRef }
+import akka.cluster.sharding.typed.scaladsl.{ClusterSharding, EntityRef}
 import akka.util.Timeout
-import akka.{ Done, NotUsed }
+import akka.{Done, NotUsed}
 import com.lightbend.lagom.scaladsl.api.ServiceCall
 import com.lightbend.lagom.scaladsl.api.transport._
 import com.lightbend.lagom.scaladsl.persistence.ReadSide
 import com.lightbend.lagom.scaladsl.server.ServerServiceCall
 import com.typesafe.config.Config
 import de.upb.cs.uc4.authentication.api.AuthenticationService
-import de.upb.cs.uc4.authentication.impl.actor.{ AuthenticationEntry, AuthenticationState }
-import de.upb.cs.uc4.authentication.impl.commands.{ AuthenticationCommand, GetAuthentication, SetAuthentication }
+import de.upb.cs.uc4.authentication.impl.actor.{AuthenticationEntry, AuthenticationState}
+import de.upb.cs.uc4.authentication.impl.commands.{AuthenticationCommand, GetAuthentication, SetAuthentication}
 import de.upb.cs.uc4.authentication.impl.readside.AuthenticationEventProcessor
 import de.upb.cs.uc4.authentication.model.AuthenticationRole.AuthenticationRole
-import de.upb.cs.uc4.authentication.model.{ AuthenticationRole, AuthenticationUser, JsonUsername, RefreshToken, Tokens }
-import de.upb.cs.uc4.shared.client.exceptions.{ CustomException, DetailedError, ErrorType, SimpleError }
+import de.upb.cs.uc4.authentication.model.{AuthenticationRole, AuthenticationUser, JsonUsername, RefreshToken, Tokens}
+import de.upb.cs.uc4.shared.client.exceptions.{CustomException, DetailedError, ErrorType, SimpleError}
 import de.upb.cs.uc4.shared.server.Hashing
 import de.upb.cs.uc4.shared.server.ServiceCallFactory._
-import de.upb.cs.uc4.shared.server.messages.{ Accepted, Confirmation, RejectedWithError }
+import de.upb.cs.uc4.shared.server.messages.{Accepted, Confirmation, RejectedWithError}
 import io.jsonwebtoken._
 
 import scala.concurrent.duration._
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.{ExecutionContext, Future}
 
 class AuthenticationServiceImpl(readSide: ReadSide, processor: AuthenticationEventProcessor,
-    clusterSharding: ClusterSharding, config: Config)(implicit ec: ExecutionContext) extends AuthenticationService {
+                                clusterSharding: ClusterSharding, config: Config)(implicit ec: ExecutionContext) extends AuthenticationService {
 
   readSide.register(processor)
 
@@ -136,7 +136,14 @@ class AuthenticationServiceImpl(readSide: ReadSide, processor: AuthenticationEve
 
   /** Generates a new login token from a refresh token in the bearer header */
   override def refreshMachineUser: ServiceCall[NotUsed, RefreshToken] = ServerServiceCall { (header, _) =>
-    val refreshToken = getBearerToken(header)
+    val refreshToken = try {
+      getBearerToken(header)
+    }
+    catch {
+      case ce: CustomException if ce.getPossibleErrorResponse.`type` == ErrorType.JwtAuthorization =>
+        throw CustomException.RefreshTokenMissing
+      case e: Throwable => throw e
+    }
     val (loginToken, _, username) = createLoginTokenFromRefreshToken(refreshToken)
 
     Future.successful(
@@ -173,7 +180,7 @@ class AuthenticationServiceImpl(readSide: ReadSide, processor: AuthenticationEve
       case Array("Basic", userAndPass) =>
         new String(Base64.getDecoder.decode(userAndPass), "UTF-8").split(":") match {
           case Array(user, password) => Option(user, password)
-          case _                     => None
+          case _ => None
         }
       case _ => None
     }
@@ -208,7 +215,7 @@ class AuthenticationServiceImpl(readSide: ReadSide, processor: AuthenticationEve
   /** Create a refresh token out of the given parameters
     *
     * @param username of the token owner
-    * @param role of the token owner
+    * @param role     of the token owner
     * @return a String tuple with the token as a string and the formatted expiration date
     */
   private def createRefreshToken(username: String, role: AuthenticationRole): (String, String) = {
@@ -234,7 +241,7 @@ class AuthenticationServiceImpl(readSide: ReadSide, processor: AuthenticationEve
   /** Create a login token out of the given parameters
     *
     * @param username of the token owner
-    * @param role of the token owner
+    * @param role     of the token owner
     * @return a tuple with the token as a string and the expiration time in minutes
     */
   private def createLoginToken(username: String, role: AuthenticationRole): (String, Int) = {
@@ -287,13 +294,13 @@ class AuthenticationServiceImpl(readSide: ReadSide, processor: AuthenticationEve
       (loginToken, logoutTimer * 60, username)
     }
     catch {
-      case _: ExpiredJwtException      => throw CustomException.RefreshTokenExpired
-      case _: UnsupportedJwtException  => throw CustomException.MalformedRefreshToken
-      case _: MalformedJwtException    => throw CustomException.MalformedRefreshToken
-      case _: SignatureException       => throw CustomException.RefreshTokenSignatureError
-      case _: IllegalArgumentException => throw CustomException.JwtAuthorizationError
-      case ce: CustomException         => throw ce
-      case _: Exception                => throw CustomException.InternalServerError
+      case _: ExpiredJwtException => throw CustomException.RefreshTokenExpired
+      case _: UnsupportedJwtException => throw CustomException.MalformedRefreshToken
+      case _: MalformedJwtException => throw CustomException.MalformedRefreshToken
+      case _: SignatureException => throw CustomException.RefreshTokenSignatureError
+      case _: IllegalArgumentException => throw CustomException.RefreshTokenMissing
+      case ce: CustomException => throw ce
+      case _: Throwable => throw CustomException.InternalServerError
     }
   }
 }

--- a/product_code/authentication_service/impl/src/main/scala/de/upb/cs/uc4/authentication/impl/readside/AuthenticationDatabase.scala
+++ b/product_code/authentication_service/impl/src/main/scala/de/upb/cs/uc4/authentication/impl/readside/AuthenticationDatabase.scala
@@ -71,7 +71,7 @@ class AuthenticationDatabase(database: Database, clusterSharding: ClusterShardin
     */
   def removeAuthenticationUser(username: String): DBIO[Done] =
     authenticationUsers
-      .filter(_.username === Hashing.sha256(username))
+      .filter(_.username === username)
       .delete
       .map(_ => Done)
       .transactionally

--- a/product_code/authentication_service/impl/src/test/resources/application.conf
+++ b/product_code/authentication_service/impl/src/test/resources/application.conf
@@ -1,0 +1,28 @@
+#
+#
+play.application.loader = de.upb.cs.uc4.authentication.impl.AuthenticationLoader
+
+uc4.authentication {
+    # the amount of days the refresh token is valid
+    refresh = 20
+    # the amount of minutes the login token is valid
+    login = 10
+}
+
+db.default {
+  driver = "org.postgresql.Driver"
+  url = "jdbc:postgresql://localhost/postgres"
+  username = "admin"
+  password = "admin"
+}
+
+jdbc-defaults.slick.profile = "slick.jdbc.PostgresProfile$"
+
+akka.actor {
+  serialization-bindings {
+    # commands won't use play-json but Akka's jackson support
+    "de.upb.cs.uc4.authentication.impl.commands.AuthenticationCommandSerializable" = jackson-json
+  }
+}
+
+lagom.circuit-breaker.default.enabled = off

--- a/product_code/authentication_service/impl/src/test/scala/de/upb/cs/uc4/authentication/impl/AuthenticationServiceSpec.scala
+++ b/product_code/authentication_service/impl/src/test/scala/de/upb/cs/uc4/authentication/impl/AuthenticationServiceSpec.scala
@@ -499,13 +499,30 @@ class AuthenticationServiceSpec extends AsyncWordSpec
     }
 
     //LOGOUT
-    "log a user out" in {
-      client.logout.withResponseHeader.invoke().map {
-        case (header: ResponseHeader, _) =>
-          val cookies = header.getHeaders("Set-Cookie")
-          cookies should have size 2
-          exactly(1, cookies) should include("refresh=;")
-          exactly(1, cookies) should include("login=;")
+    "log a user out, which" must {
+
+      "set the right amount of cookies" in {
+        client.logout.withResponseHeader.invoke().map {
+          case (header: ResponseHeader, _) =>
+            val cookies = header.getHeaders("Set-Cookie")
+            cookies should have size 2
+        }
+      }
+
+      "clears the refresh cookie" in {
+        client.logout.withResponseHeader.invoke().map {
+          case (header: ResponseHeader, _) =>
+            val cookies = header.getHeaders("Set-Cookie")
+            exactly(1, cookies) should include("refresh=;")
+        }
+      }
+
+      "clears the login cookie" in {
+        client.logout.withResponseHeader.invoke().map {
+          case (header: ResponseHeader, _) =>
+            val cookies = header.getHeaders("Set-Cookie")
+            exactly(1, cookies) should include("login=;")
+        }
       }
     }
 

--- a/product_code/build.sbt
+++ b/product_code/build.sbt
@@ -153,7 +153,7 @@ lazy val authentication_service = (project in file("authentication_service/impl"
   )
   .settings(commonSettings("authentication_service"))
   .settings(dockerSettings)
-  .settings(version := "v0.8.2")
+  .settings(version := "v0.9.0")
   .dependsOn(authentication_service_api, user_service_api % withTests, shared_server)
 
 lazy val user_service_api = (project in file("user_service/api"))

--- a/product_code/build.sbt
+++ b/product_code/build.sbt
@@ -9,7 +9,7 @@ lagomCassandraEnabled in ThisBuild := false
 
 // the Scala version that will be used for cross-compiled libraries
 scalaVersion in ThisBuild := "2.13.0"
-scalacOptions in ThisBuild ++= Seq("-deprecation")
+scalacOptions in ThisBuild ++= Seq("-deprecation", "-feature")
 
 
 def commonSettings(project: String) = Seq(

--- a/product_code/matriculation_service/impl/src/test/scala/de/upb/cs/uc4/matriculation/impl/MatriculationServiceSpec.scala
+++ b/product_code/matriculation_service/impl/src/test/scala/de/upb/cs/uc4/matriculation/impl/MatriculationServiceSpec.scala
@@ -20,6 +20,8 @@ import play.api.libs.json.Json
 import de.upb.cs.uc4.hyperledger.HyperledgerUtils.JsonUtil.ToJsonUtil
 import de.upb.cs.uc4.shared.client.exceptions.{ CustomException, DetailedError, ErrorType, SimpleError }
 
+import scala.language.reflectiveCalls
+
 /** Tests for the MatriculationService
   */
 class MatriculationServiceSpec extends AsyncWordSpec with Matchers with BeforeAndAfterAll with DefaultTestUsers {

--- a/product_code/project/Version.scala
+++ b/product_code/project/Version.scala
@@ -2,7 +2,7 @@
 object Version {
 
   private val versions: Map[String, String] = Map(
-    "authentication_service" -> "v0.8.2",
+    "authentication_service" -> "v0.9.0",
     "course_service" -> "v0.8.2",
     "hyperledger_api" -> "v0.8.0",
     "matriculation_service" -> "v0.8.4",


### PR DESCRIPTION
### Reason for this PR
- Authentication Service tests were no unit tests

### Changes in this PR
- Adjusted tests to now be Unit-Tests
- Fixed bug that prevented authentication users being deleted from the tables
- Fixed bug that lead to a wrong error being shown when the refresh token was missing for machine users

- [X] Test written
- [x] Changelog updated
