### PR TITLE
Separate build.sbt in multiple files

### DIFF
--- a/product_code/build.sbt
+++ b/product_code/build.sbt
@@ -1,4 +1,3 @@
-import sbt._
 
 // Global Settings
 organization in ThisBuild := "de.upb.cs.uc4"

--- a/product_code/build.sbt
+++ b/product_code/build.sbt
@@ -1,64 +1,13 @@
-import com.typesafe.sbt.packager.docker.DockerChmodType
+import sbt._
 
+// Global Settings
 organization in ThisBuild := "de.upb.cs.uc4"
 lagomServiceEnableSsl in ThisBuild := true
-val hyperledgerApiVersion = "v0.8.0"
-
-// The project uses PostgreSQL
 lagomCassandraEnabled in ThisBuild := false
-
-// the Scala version that will be used for cross-compiled libraries
 scalaVersion in ThisBuild := "2.13.0"
 scalacOptions in ThisBuild ++= Seq("-deprecation")
 
-
-def commonSettings(project: String) = Seq(
-  testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-h", "target/test_reports/" + project)
-)
-
 val withTests = "compile->compile;test->test"
-
-// Docker
-val dockerSettings = Seq(
-  dockerUpdateLatest := true,
-  dockerBaseImage := "adoptopenjdk/openjdk8",
-  dockerUsername := Some("uc4official"),
-  dockerChmodType := DockerChmodType.UserGroupWriteExecute,
-)
-
-// Dependencies
-val macwire = "com.softwaremill.macwire" %% "macros" % "2.3.3" % "provided"
-val scalaTest = "org.scalatest" %% "scalatest" % "3.2.0" % Test
-val flexmark = "com.vladsch.flexmark" % "flexmark-all" % "0.35.10" % Test
-val guava = "com.google.guava" % "guava" % "29.0-jre"
-val akkaDiscoveryKubernetes = "com.lightbend.akka.discovery" %% "akka-discovery-kubernetes-api" % "1.0.8"
-val postgresDriver = "org.postgresql" % "postgresql" % "42.2.8"
-val uuid = "com.fasterxml.uuid" % "java-uuid-generator" % "3.1.0"
-val janino = "org.codehaus.janino" % "janino" % "2.5.16"
-val hyperledger_api = RootProject(uri("https://github.com/upb-uc4/hlf-api.git#%s".format(hyperledgerApiVersion)))
-
-val apiDefaultDependencies = Seq(
-  lagomScaladslApi,
-  scalaTest,
-  flexmark
-)
-
-val implDefaultDependencies = Seq(
-  lagomScaladslTestKit,
-  lagomScaladslAkkaDiscovery,
-  akkaDiscoveryKubernetes,
-  filters,
-  macwire,
-  scalaTest,
-  flexmark,
-  janino
-)
-
-val defaultPersistenceKafkaDependencies = Seq(
-  lagomScaladslPersistenceJdbc,
-  postgresDriver,
-  lagomScaladslKafkaBroker,
-)
 
 // Projects
 lazy val lagom = (project in file("."))
@@ -76,26 +25,28 @@ lazy val lagom = (project in file("."))
 // This project is not allowed to have lagom server dependencies
 lazy val shared_client = (project in file("shared/client"))
   .settings(
-    libraryDependencies ++= apiDefaultDependencies,
-    libraryDependencies += scalaTest,
-    libraryDependencies += flexmark,
-    libraryDependencies += janino
+    libraryDependencies ++= Dependencies.apiDefaultDependencies,
+    libraryDependencies ++= Seq(
+      Dependencies.scalaTest,
+      Dependencies.flexmark,
+      Dependencies.janino
+    )
   )
-  .settings(commonSettings("shared_client"))
+  .settings(Settings.commonSettings("shared_client"))
 
 lazy val shared_server = (project in file("shared/server"))
   .settings(
     libraryDependencies ++= Seq(
       lagomScaladslServer,
       lagomScaladslTestKit,
-      scalaTest,
-      flexmark,
       filters,
-      guava,
-      macwire
+      Dependencies.scalaTest,
+      Dependencies.flexmark,
+      Dependencies.guava,
+      Dependencies.macwire
     )
   )
-  .settings(commonSettings("shared_server"))
+  .settings(Settings.commonSettings("shared_server"))
   .dependsOn(shared_client, authentication_service_api)
 
 lazy val hyperledger_component = (project in file("hyperledger_component"))
@@ -104,90 +55,53 @@ lazy val hyperledger_component = (project in file("hyperledger_component"))
       lagomScaladslServer,
       lagomScaladslCluster,
       lagomScaladslTestKit,
-      scalaTest,
-      flexmark,
-      macwire
+      Dependencies.scalaTest,
+      Dependencies.flexmark,
+      Dependencies.macwire
     )
   )
-  .settings(commonSettings("hyperledger_component"))
-  .dependsOn(shared_server, hyperledger_api)
-
-/*
-    mappings in Docker += file("hyperledger_service/impl/src/main/resources/hyperledger_assets/connection_profile_release.yaml")
-      -> "opt/docker/share/hyperledger_assets/connection_profile.yaml",
-    mappings in Docker += file("hyperledger_service/impl/src/main/resources/hyperledger_assets/wallet/cli.id")
-      -> "opt/docker/share/hyperledger_assets/wallet/cli.id",
- */
+  .settings(Settings.commonSettings("hyperledger_component"))
+  .dependsOn(shared_server, Dependencies.hyperledger_api)
 
 lazy val course_service_api = (project in file("course_service/api"))
-  .settings(
-    libraryDependencies ++= apiDefaultDependencies
-  )
-  .settings(commonSettings("course_service_api"))
+  .settings(Settings.apiSettings("course_service_api"))
   .dependsOn(shared_client)
 
 lazy val course_service = (project in file("course_service/impl"))
   .enablePlugins(LagomScala)
   .settings(
-    libraryDependencies ++= implDefaultDependencies,
-    libraryDependencies ++= defaultPersistenceKafkaDependencies,
-    libraryDependencies += uuid
+    libraryDependencies ++= Dependencies.defaultPersistenceKafkaDependencies,
+    libraryDependencies += Dependencies.uuid
   )
-  .settings(commonSettings("course_service"))
-  .settings(dockerSettings)
-  .settings(version := "v0.8.2")
+  .settings(Settings.implSettings("course_service"))
   .dependsOn(course_service_api, user_service_api % withTests, shared_server)
 
 lazy val authentication_service_api = (project in file("authentication_service/api"))
-  .settings(
-    libraryDependencies ++= apiDefaultDependencies
-  )
-  .settings(commonSettings("authentication_service_api"))
+  .settings(Settings.apiSettings("authentication_service_api"))
   .dependsOn(shared_client)
 
 lazy val authentication_service = (project in file("authentication_service/impl"))
   .enablePlugins(LagomScala)
-  .settings(
-    libraryDependencies ++= implDefaultDependencies,
-    libraryDependencies ++= defaultPersistenceKafkaDependencies,
-  )
-  .settings(commonSettings("authentication_service"))
-  .settings(dockerSettings)
-  .settings(version := "v0.8.2")
+  .settings(libraryDependencies ++= Dependencies.defaultPersistenceKafkaDependencies)
+  .settings(Settings.implSettings("authentication_service"))
   .dependsOn(authentication_service_api, user_service_api % withTests, shared_server)
 
 lazy val user_service_api = (project in file("user_service/api"))
-  .settings(
-    libraryDependencies ++= apiDefaultDependencies
-  )
-  .settings(commonSettings("user_service_api"))
+  .settings(Settings.apiSettings("user_service_api"))
   .dependsOn(authentication_service_api % withTests, matriculation_service_api, shared_client)
 
 lazy val user_service = (project in file("user_service/impl"))
   .enablePlugins(LagomScala)
-  .settings(
-    libraryDependencies ++= implDefaultDependencies,
-    libraryDependencies ++= defaultPersistenceKafkaDependencies,
-  )
-  .settings(commonSettings("user_service"))
-  .settings(dockerSettings)
-  .settings(version := "v0.8.3")
+  .settings(libraryDependencies ++= Dependencies.defaultPersistenceKafkaDependencies)
+  .settings(Settings.implSettings("user_service"))
   .dependsOn(user_service_api % withTests, shared_server, shared_client)
 
 lazy val matriculation_service_api = (project in file("matriculation_service/api"))
-  .settings(
-    libraryDependencies ++= apiDefaultDependencies
-  )
-  .settings(commonSettings("matriculation_service_api"))
+  .settings(Settings.apiSettings("matriculation_service_api"))
   .dependsOn(shared_client)
 
 lazy val matriculation_service = (project in file("matriculation_service/impl"))
   .enablePlugins(LagomScala)
-  .settings(
-    libraryDependencies ++= implDefaultDependencies,
-    libraryDependencies += lagomScaladslKafkaBroker
-  )
-  .settings(commonSettings("matriculation_service"))
-  .settings(dockerSettings)
-  .settings(version := "v0.8.4")
+  .settings(libraryDependencies += lagomScaladslKafkaBroker)
+  .settings(Settings.implSettings("matriculation_service"))
   .dependsOn(user_service_api % withTests, shared_server, shared_client, matriculation_service_api, hyperledger_component)

--- a/product_code/project/Dependencies.scala
+++ b/product_code/project/Dependencies.scala
@@ -1,0 +1,38 @@
+import com.lightbend.lagom.sbt.LagomImport._
+import play.sbt.PlayImport.filters
+import sbt._
+
+object Dependencies {
+  val macwire = "com.softwaremill.macwire" %% "macros" % "2.3.3" % "provided"
+  val scalaTest = "org.scalatest" %% "scalatest" % "3.2.0" % Test
+  val flexmark = "com.vladsch.flexmark" % "flexmark-all" % "0.35.10" % Test
+  val guava = "com.google.guava" % "guava" % "29.0-jre"
+  val akkaDiscoveryKubernetes = "com.lightbend.akka.discovery" %% "akka-discovery-kubernetes-api" % "1.0.8"
+  val postgresDriver = "org.postgresql" % "postgresql" % "42.2.8"
+  val uuid = "com.fasterxml.uuid" % "java-uuid-generator" % "3.1.0"
+  val janino = "org.codehaus.janino" % "janino" % "2.5.16"
+  val hyperledger_api = RootProject(uri("https://github.com/upb-uc4/hlf-api.git#%s".format(Version("hyperledger_api"))))
+
+  val apiDefaultDependencies = Seq(
+    lagomScaladslApi,
+    scalaTest,
+    flexmark
+  )
+
+  val implDefaultDependencies = Seq(
+    lagomScaladslTestKit,
+    lagomScaladslAkkaDiscovery,
+    akkaDiscoveryKubernetes,
+    filters,
+    macwire,
+    scalaTest,
+    flexmark,
+    janino
+  )
+
+  val defaultPersistenceKafkaDependencies = Seq(
+    lagomScaladslPersistenceJdbc,
+    postgresDriver,
+    lagomScaladslKafkaBroker
+  )
+}

--- a/product_code/project/Settings.scala
+++ b/product_code/project/Settings.scala
@@ -1,0 +1,41 @@
+import com.typesafe.sbt.packager.docker.DockerChmodType
+import com.typesafe.sbt.packager.docker.DockerPlugin.autoImport.{ dockerBaseImage, dockerChmodType, dockerUpdateLatest, dockerUsername }
+import sbt.Keys._
+import sbt.{ Def, TestFrameworks, Tests }
+
+object Settings {
+
+  private def dockerSettings(project: String) = Seq(
+    dockerUpdateLatest := true,
+    dockerBaseImage := "adoptopenjdk/openjdk8",
+    dockerUsername := Some("uc4official"),
+    dockerChmodType := DockerChmodType.UserGroupWriteExecute,
+    version := Version(project)
+  )
+
+  /** The settings every project needs
+    *
+    * @param project name of the project
+    */
+  def commonSettings(project: String): Seq[Def.Setting[_]] = Seq(
+    testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-h", "target/test_reports/" + project)
+  )
+
+  /** The settings every api project needs
+    * This includes the common settings
+    * and the needed dependencies
+    *
+    * @param project name of the project
+    */
+  def apiSettings(project: String): Seq[Def.Setting[_]] =
+    commonSettings(project) ++ Seq(libraryDependencies ++= Dependencies.apiDefaultDependencies)
+
+  /** The settings every impl project needs
+    * This includes the common settings
+    * and the needed dependencies
+    *
+    * @param project name of the project
+    */
+  def implSettings(project: String): Seq[Def.Setting[_]] =
+    commonSettings(project) ++ dockerSettings(project) ++ Seq(libraryDependencies ++= Dependencies.implDefaultDependencies)
+}

--- a/product_code/project/Version.scala
+++ b/product_code/project/Version.scala
@@ -1,0 +1,17 @@
+
+object Version {
+
+  private val versions: Map[String, String] = Map(
+    "authentication_service" -> "v0.8.2",
+    "course_service" -> "v0.8.2",
+    "hyperledger_api" -> "v0.8.0",
+    "matriculation_service" -> "v0.8.4",
+    "user_service" -> "v0.8.3"
+  )
+
+  /** Returns the version of a project
+    *
+    * @param project name of the project
+    */
+  def apply(project: String): String = versions(project)
+}


### PR DESCRIPTION
### Reason for this PR
- The build.sbt was getting to big to handle it in an easy way

### Changes in this PR
- Created own file for the dependencies
- Created own file for the version management of every service
- Created own file for the settings that every service needs
