### PR TITLE
Add pseudonymisation in MatriculationService

### DIFF
--- a/product_code/build.sbt
+++ b/product_code/build.sbt
@@ -108,7 +108,7 @@ lazy val matriculation_service = (project in file("matriculation_service/impl"))
   .enablePlugins(LagomScala)
   .settings(libraryDependencies += lagomScaladslKafkaBroker)
   .settings(Settings.implSettings("matriculation_service"))
-  .dependsOn(user_service_api % withTests, shared_server, shared_client, matriculation_service_api, hyperledger_component)
+  .dependsOn(user_service_api % withTests, certificate_service_api % withTests, shared_server, shared_client, matriculation_service_api, hyperledger_component)
 
 lazy val certificate_service_api = (project in file("certificate_service/api"))
   .settings(Settings.apiSettings("certificate_service_api"))

--- a/product_code/certificate_service/api/src/test/scala/de/upb/cs/uc4/certificate/CertificateServiceStub.scala
+++ b/product_code/certificate_service/api/src/test/scala/de/upb/cs/uc4/certificate/CertificateServiceStub.scala
@@ -67,4 +67,10 @@ class CertificateServiceStub extends CertificateService {
 
   /** This Methods needs to allow a GET-Method */
   override def allowVersionNumber: ServiceCall[NotUsed, Done] = ServiceCall { _ => Future.successful(Done) }
+
+  /** Allows POST */
+  override def allowedPost: ServiceCall[NotUsed, Done] = ServiceCall { _ => Future.successful(Done) }
+
+  /** Allows GET */
+  override def allowedGet: ServiceCall[NotUsed, Done] = ServiceCall { _ => Future.successful(Done) }
 }

--- a/product_code/certificate_service/api/src/test/scala/de/upb/cs/uc4/certificate/CertificateServiceStub.scala
+++ b/product_code/certificate_service/api/src/test/scala/de/upb/cs/uc4/certificate/CertificateServiceStub.scala
@@ -1,0 +1,70 @@
+package de.upb.cs.uc4.certificate
+
+import akka.{ Done, NotUsed }
+import com.lightbend.lagom.scaladsl.api.ServiceCall
+import de.upb.cs.uc4.certificate.api.CertificateService
+import de.upb.cs.uc4.certificate.model.{ EncryptedPrivateKey, JsonCertificate, JsonEnrollmentId, PostMessageCSR }
+import de.upb.cs.uc4.shared.client.exceptions.UC4Exception
+
+import scala.collection.mutable
+import scala.concurrent.Future
+
+class CertificateServiceStub extends CertificateService {
+  private val certificateUsers = mutable.HashMap[String, CertificateUserEntry]()
+
+  /** Create CertficateUser data for the given usernames. Without futures, for your convenience.
+    *
+    */
+  def setup(usernames: String*): Unit = {
+    usernames.foreach { username =>
+      certificateUsers.put(username, CertificateUserEntry(username + "enrollmentId", username + "enrollmentSecret", username + "certificate", EncryptedPrivateKey("", "", "")))
+    }
+  }
+
+  /** Fetch CertficateUser data for the given username. Without futures, for your convenience.
+    *
+    */
+  def get(username: String): CertificateUserEntry = {
+    certificateUsers.get(username) match {
+      case Some(certificateUserEntry) => certificateUserEntry
+      case None => throw UC4Exception.NotFound
+    }
+  }
+
+  /** Forwards the certificate signing request from the given user */
+  override def setCertificate(username: String): ServiceCall[PostMessageCSR, Done] = ServiceCall {
+    postMessageCSR =>
+      certificateUsers.put(username, CertificateUserEntry(username + "enrollmentId", username + "enrollmentSecret", username + "certificate", postMessageCSR.encryptedPrivateKey))
+      Future.successful(Done)
+  }
+
+  /** Returns the certificate of the given user */
+  override def getCertificate(username: String): ServiceCall[NotUsed, JsonCertificate] = ServiceCall {
+    _ =>
+      certificateUsers.get(username) match {
+        case Some(certificateUserEntry) => Future.successful(JsonCertificate(certificateUserEntry.certificate))
+        case None => Future.failed(UC4Exception.NotFound)
+      }
+  }
+
+  /** Returns the enrollment id of the given user */
+  override def getEnrollmentId(username: String): ServiceCall[NotUsed, JsonEnrollmentId] = ServiceCall {
+    _ =>
+      certificateUsers.get(username) match {
+        case Some(certificateUserEntry) => Future.successful(JsonEnrollmentId(certificateUserEntry.enrollmentId))
+        case None => Future.failed(UC4Exception.NotFound)
+      }
+  }
+
+  /** Returns the encrypted private key of the given user */
+  override def getPrivateKey(username: String): ServiceCall[NotUsed, EncryptedPrivateKey] = ServiceCall {
+    _ =>
+      certificateUsers.get(username) match {
+        case Some(certificateUserEntry) => Future.successful(certificateUserEntry.encryptedPrivateKey)
+        case None => Future.failed(UC4Exception.NotFound)
+      }
+  }
+
+  /** This Methods needs to allow a GET-Method */
+  override def allowVersionNumber: ServiceCall[NotUsed, Done] = ServiceCall { _ => Future.successful(Done) }
+}

--- a/product_code/certificate_service/api/src/test/scala/de/upb/cs/uc4/certificate/CertificateUserEntry.scala
+++ b/product_code/certificate_service/api/src/test/scala/de/upb/cs/uc4/certificate/CertificateUserEntry.scala
@@ -1,0 +1,8 @@
+package de.upb.cs.uc4.certificate
+
+import de.upb.cs.uc4.certificate.model.EncryptedPrivateKey
+
+/** Helper class for CertificateServiceStub, used to represent the data stored in a single actor
+  *
+  */
+case class CertificateUserEntry(enrollmentId: String, enrollmentSecret: String, certificate: String, encryptedPrivateKey: EncryptedPrivateKey)

--- a/product_code/matriculation_service/CHANGELOG.md
+++ b/product_code/matriculation_service/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [v.0.10.1-WIP](https://github.com/upb-uc4/University-Credits-4.0/compare/matriculation-v0.10.0...matriculation-v0.10.1) (2020-XX-XX)
+## Feature
+- Added Pseudonymisation by using enrollmentId instead of matriculationId
+- Removed FirstName, LastName and BirthDate from MatriculationData
+## Refactor
+## Bugfix
+
 # [v.0.10.0](https://github.com/upb-uc4/University-Credits-4.0/compare/matriculation-v0.9.0...matriculation-v0.10.0) (2020-10-12)
 ## Feature
 - Wrap Validation in Future to enable timeouts

--- a/product_code/matriculation_service/api/src/main/scala/de/upb/cs/uc4/matriculation/model/ImmatriculationData.scala
+++ b/product_code/matriculation_service/api/src/main/scala/de/upb/cs/uc4/matriculation/model/ImmatriculationData.scala
@@ -3,10 +3,7 @@ package de.upb.cs.uc4.matriculation.model
 import play.api.libs.json.{ Format, Json }
 
 case class ImmatriculationData(
-    matriculationId: String,
-    firstName: String,
-    lastName: String,
-    birthDate: String,
+    enrollmentId: String,
     matriculationStatus: Seq[SubjectMatriculation]
 )
 

--- a/product_code/matriculation_service/impl/src/main/scala/de/upb/cs/uc4/matriculation/impl/MatriculationApplication.scala
+++ b/product_code/matriculation_service/impl/src/main/scala/de/upb/cs/uc4/matriculation/impl/MatriculationApplication.scala
@@ -3,6 +3,7 @@ package de.upb.cs.uc4.matriculation.impl
 import com.lightbend.lagom.scaladsl.playjson.JsonSerializerRegistry
 import com.lightbend.lagom.scaladsl.server.{ LagomApplicationContext, LagomServer }
 import com.softwaremill.macwire.wire
+import de.upb.cs.uc4.certificate.api.CertificateService
 import de.upb.cs.uc4.hyperledger.HyperledgerComponent
 import de.upb.cs.uc4.matriculation.api.MatriculationService
 import de.upb.cs.uc4.matriculation.impl.actor.MatriculationBehaviour
@@ -17,6 +18,9 @@ abstract class MatriculationApplication(context: LagomApplicationContext)
 
   // Bind UserService
   lazy val userService: UserService = serviceClient.implement[UserService]
+
+  //Bind CertificateService
+  lazy val certificateService: CertificateService = serviceClient.implement[CertificateService]
 
   // Register the JSON serializer registry
   override lazy val jsonSerializerRegistry: JsonSerializerRegistry = MatriculationSerializerRegistry


### PR DESCRIPTION
### Reason for this PR
- With the introduction of enrollmentIds, the identifying information of matriculationId can be replaced by the pseudonymisation of enrollmentIds

### Changes in this PR
- Changed the MatriculationData to use enrollmentIds from the CertificateService
- Removed MatriculationId, name, birthDate from MatriculationData

- [X] Test written
- [x] Changelog updated
