### PR TITLE
Rename default users

### DIFF
--- a/product_code/user_service/CHANGELOG.md
+++ b/product_code/user_service/CHANGELOG.md
@@ -1,7 +1,7 @@
 # [WIP - v0.11.1](https://github.com/upb-uc4/University-Credits-4.0/compare/user-v0.11.0...user-v0.11.1) (2020-XX-XX)
 ## Feature
 ## Refactor
- - Changed e-mail addresses, first names and last names for the default users
+ - Changed email addresses, first names and last names for the default users
 ## Bugfix
 
 # [v0.11.0](https://github.com/upb-uc4/University-Credits-4.0/compare/user-v0.10.1...user-v0.11.0) (2020-10-26)

--- a/product_code/user_service/CHANGELOG.md
+++ b/product_code/user_service/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [WIP - v0.11.1](https://github.com/upb-uc4/University-Credits-4.0/compare/user-v0.11.0...user-v0.11.1) (2020-XX-XX)
+## Feature
+## Refactor
+ - Changed e-mail addresses, first names and last names for the default users
+## Bugfix
+
 # [v0.11.0](https://github.com/upb-uc4/University-Credits-4.0/compare/user-v0.10.1...user-v0.11.0) (2020-10-26)
 ## Feature
  - Changed the Circuit Breaker to ignore UC4NonCriticalExceptions

--- a/product_code/user_service/impl/src/main/scala/de/upb/cs/uc4/user/impl/readside/UserDatabase.scala
+++ b/product_code/user_service/impl/src/main/scala/de/upb/cs/uc4/user/impl/readside/UserDatabase.scala
@@ -67,9 +67,9 @@ class UserDatabase(database: Database, clusterSharding: ClusterSharding)(implici
       students.schema.createIfNotExists.andFinally(DBIO.successful {
         //Add default users
         val address: Address = Address("Gänseweg", "42a", "13337", "Entenhausen", "Germany")
-        val student: User = Student("student", Role.Student, address, "firstName", "LastName", "example@mail.de", "+49123456789", "1990-12-11", "", "7421769")
-        val lecturer: User = Lecturer("lecturer", Role.Lecturer, address, "firstName", "LastName", "example@mail.de", "+49123456789", "1991-12-11", "Heute kommt der kleine Gauss dran.", "Mathematics")
-        val admin: User = Admin("admin", Role.Admin, address, "firstName", "LastName", "example@mail.de", "+49123456789", "1992-12-10")
+        val student: User = Student("student", Role.Student, address, "Stu", "Dent", "student@mail.de", "+49123456789", "1990-12-11", "", "7421769")
+        val lecturer: User = Lecturer("lecturer", Role.Lecturer, address, "Lect", "Urer", "lecturer@mail.de", "+49123456789", "1991-12-11", "Heute kommt der kleine Gauss dran.", "Mathematics")
+        val admin: User = Admin("admin", Role.Admin, address, "Ad", "Min", "admin@mail.de", "+49123456789", "1992-12-10")
 
         addDefaultUser(student)
         addDefaultUser(lecturer)


### PR DESCRIPTION
### Reason for this PR
- #353 

### Changes in this PR
- Adjusted names of default users (first and last name)
- Changed email addresses of the default users

- [x] Changelog updated
