### PR TITLE
Delete certificate user

### DIFF
--- a/product_code/certificate_service/CHANGELOG.md
+++ b/product_code/certificate_service/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [WIP v0.11.1](https://github.com/upb-uc4/University-Credits-4.0/compare/certificate-v0.11.0...certificate-v0.11.1) (2020-XX-XX)
+## Feature
+## Refactor
+## Bugfix
+- Added certificate state deletion if corresponding user gets deleted
+
+
 # [v0.11.0](https://github.com/upb-uc4/University-Credits-4.0/compare/certificate-v0.10.3...certificate-v0.11.0) (2020-10-26)
 ## Feature
  - Changed Circuit Breaker to ignore UC4NonCriticalExceptions

--- a/product_code/certificate_service/impl/src/main/scala/de/upb/cs/uc4/certificate/impl/CertificateSerializerRegistry.scala
+++ b/product_code/certificate_service/impl/src/main/scala/de/upb/cs/uc4/certificate/impl/CertificateSerializerRegistry.scala
@@ -1,7 +1,7 @@
 package de.upb.cs.uc4.certificate.impl
 
 import com.lightbend.lagom.scaladsl.playjson.JsonSerializer
-import de.upb.cs.uc4.certificate.impl.events.{ OnCertficateAndKeySet, OnRegisterUser }
+import de.upb.cs.uc4.certificate.impl.events.{ OnCertficateAndKeySet, OnCertificateUserDelete, OnRegisterUser }
 import de.upb.cs.uc4.shared.server.SharedSerializerRegistry
 
 import scala.collection.immutable.Seq
@@ -17,6 +17,7 @@ import scala.collection.immutable.Seq
 object CertificateSerializerRegistry extends SharedSerializerRegistry {
   override def customSerializers: Seq[JsonSerializer[_]] = Seq(
     JsonSerializer[OnRegisterUser],
-    JsonSerializer[OnCertficateAndKeySet]
+    JsonSerializer[OnCertficateAndKeySet],
+    JsonSerializer[OnCertificateUserDelete]
   )
 }

--- a/product_code/certificate_service/impl/src/main/scala/de/upb/cs/uc4/certificate/impl/actor/CertificateState.scala
+++ b/product_code/certificate_service/impl/src/main/scala/de/upb/cs/uc4/certificate/impl/actor/CertificateState.scala
@@ -3,8 +3,8 @@ package de.upb.cs.uc4.certificate.impl.actor
 import akka.cluster.sharding.typed.scaladsl.EntityTypeKey
 import akka.persistence.typed.scaladsl.{ Effect, ReplyEffect }
 import de.upb.cs.uc4.certificate.impl.CertificateApplication
-import de.upb.cs.uc4.certificate.impl.commands.{ CertificateCommand, GetCertificateUser, RegisterUser, SetCertificateAndKey }
-import de.upb.cs.uc4.certificate.impl.events.{ CertificateEvent, OnCertficateAndKeySet, OnRegisterUser }
+import de.upb.cs.uc4.certificate.impl.commands.{ CertificateCommand, DeleteCertificateUser, GetCertificateUser, RegisterUser, SetCertificateAndKey }
+import de.upb.cs.uc4.certificate.impl.events.{ CertificateEvent, OnCertficateAndKeySet, OnCertificateUserDelete, OnRegisterUser }
 import de.upb.cs.uc4.certificate.model.EncryptedPrivateKey
 import de.upb.cs.uc4.shared.server.messages.Accepted
 import play.api.libs.json.{ Format, Json }
@@ -29,6 +29,8 @@ case class CertificateState(
         Effect.reply(replyTo)(enrollmentId, enrollmentSecret, certificate, encryptedPrivateKey)
       case SetCertificateAndKey(certificate, encryptedPrivateKey, replyTo) =>
         Effect.persist(OnCertficateAndKeySet(certificate, encryptedPrivateKey)).thenReply(replyTo) { _ => Accepted }
+      case DeleteCertificateUser(username, replyTo) =>
+        Effect.persist(OnCertificateUserDelete(username)).thenReply(replyTo) { _ => Accepted }
       case _ =>
         println("Unknown Command")
         Effect.noReply
@@ -44,6 +46,8 @@ case class CertificateState(
         copy(enrollmentId = Some(id), enrollmentSecret = Some(secret))
       case OnCertficateAndKeySet(cert, key) =>
         copy(certificate = Some(cert), encryptedPrivateKey = Some(key))
+      case OnCertificateUserDelete(username) =>
+        CertificateState.initial
       case _ =>
         println("Unknown Event")
         this

--- a/product_code/certificate_service/impl/src/main/scala/de/upb/cs/uc4/certificate/impl/commands/DeleteCertificateUser.scala
+++ b/product_code/certificate_service/impl/src/main/scala/de/upb/cs/uc4/certificate/impl/commands/DeleteCertificateUser.scala
@@ -1,0 +1,6 @@
+package de.upb.cs.uc4.certificate.impl.commands
+
+import akka.actor.typed.ActorRef
+import de.upb.cs.uc4.shared.server.messages.Confirmation
+
+case class DeleteCertificateUser(username: String, replyTo: ActorRef[Confirmation]) extends CertificateCommand

--- a/product_code/certificate_service/impl/src/main/scala/de/upb/cs/uc4/certificate/impl/events/OnCertificateUserDelete.scala
+++ b/product_code/certificate_service/impl/src/main/scala/de/upb/cs/uc4/certificate/impl/events/OnCertificateUserDelete.scala
@@ -1,0 +1,9 @@
+package de.upb.cs.uc4.certificate.impl.events
+
+import play.api.libs.json.{ Format, Json }
+
+case class OnCertificateUserDelete(username: String) extends CertificateEvent
+
+object OnCertificateUserDelete {
+  implicit val format: Format[OnCertificateUserDelete] = Json.format
+}

--- a/product_code/certificate_service/impl/src/test/scala/de/upb/cs/uc4/certificate/impl/CertificateStateSpec.scala
+++ b/product_code/certificate_service/impl/src/test/scala/de/upb/cs/uc4/certificate/impl/CertificateStateSpec.scala
@@ -5,7 +5,7 @@ import java.util.UUID
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.persistence.typed.PersistenceId
 import de.upb.cs.uc4.certificate.impl.actor.CertificateBehaviour
-import de.upb.cs.uc4.certificate.impl.commands.{ GetCertificateUser, RegisterUser, SetCertificateAndKey }
+import de.upb.cs.uc4.certificate.impl.commands.{ DeleteCertificateUser, GetCertificateUser, RegisterUser, SetCertificateAndKey }
 import de.upb.cs.uc4.certificate.model.EncryptedPrivateKey
 import de.upb.cs.uc4.shared.server.messages.{ Accepted, Confirmation }
 import org.scalatest.matchers.should.Matchers
@@ -82,6 +82,24 @@ class CertificateStateSpec extends ScalaTestWithActorTestKit(s"""
       val probe2 = createTestProbe[Confirmation]()
       ref ! SetCertificateAndKey("certificate", EncryptedPrivateKey("key", "iv", "salt"), probe2.ref)
       probe2.expectMessage(Accepted)
+    }
+
+    //DELETE
+    "delete a CertificateUser" in {
+      val probe1 = createTestProbe[Confirmation]()
+      val probe2 = createTestProbe[Confirmation]()
+      val probe3 = createTestProbe[(Option[String], Option[String], Option[String], Option[EncryptedPrivateKey])]()
+
+      val ref = spawn(CertificateBehaviour.create(PersistenceId("fake-type-hint", "fake-id-7")))
+
+      ref ! RegisterUser("enrollmentId", "enrollmentSecret", probe1.ref)
+      probe1.expectMessage(Accepted)
+
+      ref ! DeleteCertificateUser("enrollmentId", probe2.ref)
+      probe2.expectMessage(Accepted)
+
+      ref ! GetCertificateUser(probe3.ref)
+      probe3.expectMessage((None, None, None, None))
     }
   }
 }


### PR DESCRIPTION
### Reason for this PR
- When a user gets deleted its corresponding certificate state should be deleted 

### Changes in this PR
- Delete certificate state upon user deletion over topic

- [x] Test written
- [x] Changelog updated
