### PR TITLE
Feature/already deleted error

### DIFF
--- a/product_code/examreg_service/impl/src/main/scala/de/upb/cs/uc4/examreg/impl/ExamregServiceImpl.scala
+++ b/product_code/examreg_service/impl/src/main/scala/de/upb/cs/uc4/examreg/impl/ExamregServiceImpl.scala
@@ -126,7 +126,7 @@ class ExamregServiceImpl(clusterSharding: ClusterSharding, database: ExamregData
       if (optExamReg.isEmpty) {
         throw UC4Exception.NotFound
       }
-      if(!optExamReg.get.active){
+      if (!optExamReg.get.active) {
         throw UC4Exception.AlreadyDeleted
       }
       val hlRef = entityRefHyperledger

--- a/product_code/examreg_service/impl/src/main/scala/de/upb/cs/uc4/examreg/impl/ExamregServiceImpl.scala
+++ b/product_code/examreg_service/impl/src/main/scala/de/upb/cs/uc4/examreg/impl/ExamregServiceImpl.scala
@@ -126,6 +126,9 @@ class ExamregServiceImpl(clusterSharding: ClusterSharding, database: ExamregData
       if (optExamReg.isEmpty) {
         throw UC4Exception.NotFound
       }
+      if(!optExamReg.get.active){
+        throw UC4Exception.AlreadyDeleted
+      }
       val hlRef = entityRefHyperledger
       hlRef.askWithStatus[Confirmation](replyTo => CloseExamregHyperledger(examregName, replyTo)).flatMap {
         case Accepted(_) =>

--- a/product_code/examreg_service/impl/src/test/scala/de/upb/cs/uc4/examreg/impl/ExamregServiceSpec.scala
+++ b/product_code/examreg_service/impl/src/test/scala/de/upb/cs/uc4/examreg/impl/ExamregServiceSpec.scala
@@ -231,6 +231,19 @@ class ExamregServiceSpec extends AsyncWordSpec
       }
     }
 
+    "not close an already inactive examination regulation" in {
+      val uniqueExamReg = examReg2.copy(name = "inactiveDuplicate")
+      client.addExaminationRegulation().handleRequestHeader(addAuthorizationHeader()).invoke(uniqueExamReg).flatMap { _ =>
+        client.closeExaminationRegulation(uniqueExamReg.name).handleRequestHeader(addAuthorizationHeader()).invoke().flatMap {
+          _ =>
+            client.closeExaminationRegulation(uniqueExamReg.name).handleRequestHeader(addAuthorizationHeader()).invoke().failed.map{
+              exception =>
+                exception.asInstanceOf[UC4Exception].possibleErrorResponse.`type` should ===(ErrorType.AlreadyDeleted)
+            }
+        }
+      }
+    }
+
     "return an error when trying to close a non-existing examination regulation" in {
       client.closeExaminationRegulation("does not exist").handleRequestHeader(addAuthorizationHeader()).invoke().failed.map { exception =>
         exception.asInstanceOf[UC4Exception].possibleErrorResponse.`type` should ===(ErrorType.KeyNotFound)

--- a/product_code/examreg_service/impl/src/test/scala/de/upb/cs/uc4/examreg/impl/ExamregServiceSpec.scala
+++ b/product_code/examreg_service/impl/src/test/scala/de/upb/cs/uc4/examreg/impl/ExamregServiceSpec.scala
@@ -236,7 +236,7 @@ class ExamregServiceSpec extends AsyncWordSpec
       client.addExaminationRegulation().handleRequestHeader(addAuthorizationHeader()).invoke(uniqueExamReg).flatMap { _ =>
         client.closeExaminationRegulation(uniqueExamReg.name).handleRequestHeader(addAuthorizationHeader()).invoke().flatMap {
           _ =>
-            client.closeExaminationRegulation(uniqueExamReg.name).handleRequestHeader(addAuthorizationHeader()).invoke().failed.map{
+            client.closeExaminationRegulation(uniqueExamReg.name).handleRequestHeader(addAuthorizationHeader()).invoke().failed.map {
               exception =>
                 exception.asInstanceOf[UC4Exception].possibleErrorResponse.`type` should ===(ErrorType.AlreadyDeleted)
             }

--- a/product_code/shared/client/src/main/scala/de/upb/cs/uc4/shared/client/exceptions/ErrorType.scala
+++ b/product_code/shared/client/src/main/scala/de/upb/cs/uc4/shared/client/exceptions/ErrorType.scala
@@ -5,7 +5,7 @@ import play.api.libs.json.{ Format, Json }
 object ErrorType extends Enumeration {
   type ErrorType = Value
   val NotModified, //304
-  Deserialization, KafkaDeserialization, JsonValidation, MalformedRefreshToken, MalformedLoginToken, UnexpectedEntity, MultipleAuthorization, //400
+  Deserialization, KafkaDeserialization, JsonValidation, AlreadyDeleted, MalformedRefreshToken, MalformedLoginToken, UnexpectedEntity, MultipleAuthorization, //400
   MissingHeader, QueryParameter, //In an DetailedError
   BasicAuthorization, JwtAuthorization, RefreshTokenExpired, LoginTokenExpired, RefreshTokenMissing, //401
   NotEnoughPrivileges, OwnerMismatch, //403
@@ -37,6 +37,7 @@ object ErrorType extends Enumeration {
       //400
       case Deserialization => "Syntax of the provided json object was incorrect"
       case JsonValidation => "The provided json object did not validate" //In a DetailedError
+      case AlreadyDeleted => "The resource was already deleted"
       case MalformedRefreshToken => "The long term token is malformed"
       case MalformedLoginToken => "The login token is malformed"
       case UnexpectedEntity => "Expected another entity" //In an InformativeError

--- a/product_code/shared/client/src/main/scala/de/upb/cs/uc4/shared/client/exceptions/UC4Exception.scala
+++ b/product_code/shared/client/src/main/scala/de/upb/cs/uc4/shared/client/exceptions/UC4Exception.scala
@@ -26,6 +26,7 @@ object UC4Exception {
   val DeserializationError = new UC4NonCriticalException(400, GenericError(ErrorType.Deserialization))
   def KafkaDeserializationError(expected: String, actual: String) = new UC4NonCriticalException(400, GenericError(ErrorType.KafkaDeserialization, s"Expected class type '$expected' but received '$actual''"))
 
+  val AlreadyDeleted = new UC4NonCriticalException(400, GenericError(ErrorType.AlreadyDeleted))
   val MalformedRefreshToken = new UC4NonCriticalException(400, GenericError(ErrorType.MalformedRefreshToken))
   val MalformedLoginToken = new UC4NonCriticalException(400, GenericError(ErrorType.MalformedLoginToken))
   val MultipleAuthorizationError = new UC4NonCriticalException(400, GenericError(ErrorType.MultipleAuthorization))


### PR DESCRIPTION
### Reason for this PR
- Since deletion is no longer final, but rather a flag (in some specific cases), we need a new "already deleted" error

### Changes in this PR
- Added a new "already deleted" error, which is thrown when a call is onvoked to delete a previously deleted resource


- [X] Test written
- [X] Changelog updated (No update necessary)
