### PR TITLE
Bugfix/default examreg creation

### DIFF
--- a/product_code/examreg_service/CHANGELOG.md
+++ b/product_code/examreg_service/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [v0.13.1](https://github.com/upb-uc4/University-Credits-4.0/compare/examreg-v0.12.3...examreg-v0.13.1) (2020-12-04)
+## Feature
+## Refactor
+ - Changed default examination regulation creation to be in parallel
+## Bugfix
+
 # [v0.12.3](https://github.com/upb-uc4/University-Credits-4.0/compare/examreg-v0.12.2...examreg-v0.12.3) (2020-11-20)
 ## Feature
  - Added Examination Regulation endpoints for 

--- a/product_code/examreg_service/impl/src/main/resources/application.conf
+++ b/product_code/examreg_service/impl/src/main/resources/application.conf
@@ -15,7 +15,7 @@ db.default {
 uc4 {
   timeouts {
     validation = 5000
-    hyperledger = 30000
+    hyperledger = 40000
   }
 }
 

--- a/product_code/project/Version.scala
+++ b/product_code/project/Version.scala
@@ -6,7 +6,7 @@ object Version {
     "certificate_service" -> "v0.13.1",
     "configuration_service" -> "v0.13.0",
     "course_service" -> "v0.13.1",
-    "examreg_service" -> "v0.12.3",
+    "examreg_service" -> "v0.13.1",
     "hyperledger_api" -> "0.11.5",
     "matriculation_service" -> "v0.13.1",
     "user_service" -> "v0.13.3"


### PR DESCRIPTION
### Reason for this PR
- On startup, default examregs are created. However, the timeouts and the fact that the creation of multiple examregs does not happen in parallel, causes the service to only create one of the examregs, sometimes two.

### Changes in this PR
- Changed Default Examregs to be created in parallel
- Changed timeout in examreg from 30 to 40 seconds

- [x] Changelog updated
