### PR TITLE
Change endpoint name for fetching hyperledger network version in Conf…

### DIFF
--- a/product_code/configuration_service/CHANGELOG.md
+++ b/product_code/configuration_service/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [v0.14.2](https://github.com/upb-uc4/University-Credits-4.0/compare/configuration-v0.14.1...configuration-v0.14.2) (2020-12-17)
+## Feature
+## Refactor
+- Renamed endpoint "version/hyperledger" to "version/hyperledger-network",
+    as the endpoint does not return the same json object that any other "version/hyperledger" endpoint returns
+## Bugfix
+
 # [v0.14.1](https://github.com/upb-uc4/University-Credits-4.0/compare/configuration-v0.13.1...configuration-v0.14.1) (2020-12-14)
 ## Feature
 ## Refactor

--- a/product_code/configuration_service/api/src/main/scala/de/upb/cs/uc4/configuration/api/ConfigurationService.scala
+++ b/product_code/configuration_service/api/src/main/scala/de/upb/cs/uc4/configuration/api/ConfigurationService.scala
@@ -45,12 +45,12 @@ trait ConfigurationService extends UC4Service {
     import Service._
     super.descriptor
       .addCalls(
-        restCall(Method.GET, pathPrefix + "/version/hyperledger", getHyperledgerNetworkVersion _),
+        restCall(Method.GET, pathPrefix + "/version/hyperledger-network", getHyperledgerNetworkVersion _),
         restCall(Method.GET, pathPrefix + "/configuration", getConfiguration _),
         restCall(Method.PUT, pathPrefix + "/configuration", setConfiguration _),
         restCall(Method.GET, pathPrefix + "/validation", getValidation _),
         restCall(Method.GET, pathPrefix + "/semester?date", getSemester _),
-        restCall(Method.OPTIONS, pathPrefix + "/version/hyperledger", allowedMethodsGET _),
+        restCall(Method.OPTIONS, pathPrefix + "/version/hyperledger-network", allowedMethodsGET _),
         restCall(Method.OPTIONS, pathPrefix + "/configuration", allowedMethodsGETPUT _),
         restCall(Method.OPTIONS, pathPrefix + "/validation", allowedMethodsGET _),
         restCall(Method.OPTIONS, pathPrefix + "/semester", allowedMethodsGET _)

--- a/product_code/project/Version.scala
+++ b/product_code/project/Version.scala
@@ -4,7 +4,7 @@ object Version {
   private val versions: Map[String, String] = Map(
     "authentication_service" -> "v0.14.1",
     "certificate_service" -> "v0.14.1",
-    "configuration_service" -> "v0.14.1",
+    "configuration_service" -> "v0.14.2",
     "course_service" -> "v0.14.1",
     "examreg_service" -> "v0.14.1",
     "hyperledger_api" -> "0.14.5",


### PR DESCRIPTION
### Reason for this PR
- The endpoint name in ConfigurationService caused some confusion, rename required

### Changes in this PR
- Renamed endpoint "version/hyperledger" to "version/hyperledger-network", as the endpoint does not return the same json object that any other "version/hyperledger" endpoint returns

- [X] Changelog updated
