### PR TITLE
Bugfix examreg caching

### DIFF
--- a/product_code/examreg_service/CHANGELOG.md
+++ b/product_code/examreg_service/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [WIP - v0.15.1](https://github.com/upb-uc4/University-Credits-4.0/compare/examreg-v0.15.0...examreg-v0.15.1) (2021-XX-XX)
+## Feature
+## Refactor
+## Bugfix
+ - Fixed missing behaviour for "GetAllExamregsHyperledger" command
+
 # [v0.15.0](https://github.com/upb-uc4/University-Credits-4.0/compare/examreg-v0.14.1...examreg-v0.15.0) (2020-12-20)
 ## Feature
 - Added caching for Examination Regulations through periodically fetching from hyperledger

--- a/product_code/examreg_service/CHANGELOG.md
+++ b/product_code/examreg_service/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Refactor
 ## Bugfix
  - Fixed missing behaviour for "GetAllExamregsHyperledger" command
+ - Fixed sequence serialization error through a wrapper class
 
 # [v0.15.0](https://github.com/upb-uc4/University-Credits-4.0/compare/examreg-v0.14.1...examreg-v0.15.0) (2020-12-20)
 ## Feature

--- a/product_code/examreg_service/api/src/main/scala/de/upb/cs/uc4/examreg/model/ExaminationRegulationsWrapper.scala
+++ b/product_code/examreg_service/api/src/main/scala/de/upb/cs/uc4/examreg/model/ExaminationRegulationsWrapper.scala
@@ -1,0 +1,9 @@
+package de.upb.cs.uc4.examreg.model
+
+import play.api.libs.json.{ Format, Json }
+
+case class ExaminationRegulationsWrapper(examinationRegulations: Seq[ExaminationRegulation])
+
+object ExaminationRegulationsWrapper {
+  implicit val format: Format[ExaminationRegulationsWrapper] = Json.format
+}

--- a/product_code/examreg_service/impl/src/main/scala/de/upb/cs/uc4/examreg/impl/ExamregSerializerRegistry.scala
+++ b/product_code/examreg_service/impl/src/main/scala/de/upb/cs/uc4/examreg/impl/ExamregSerializerRegistry.scala
@@ -3,7 +3,7 @@ package de.upb.cs.uc4.examreg.impl
 import com.lightbend.lagom.scaladsl.playjson.JsonSerializer
 import de.upb.cs.uc4.examreg.impl.actor.ExamregState
 import de.upb.cs.uc4.examreg.impl.events.{ OnExamregClose, OnExamregCreate }
-import de.upb.cs.uc4.examreg.model.ExaminationRegulation
+import de.upb.cs.uc4.examreg.model.{ ExaminationRegulation, ExaminationRegulationsWrapper }
 import de.upb.cs.uc4.shared.server.SharedSerializerRegistry
 
 import scala.collection.immutable.Seq
@@ -27,6 +27,7 @@ object ExamregSerializerRegistry extends SharedSerializerRegistry {
     JsonSerializer[OnExamregClose],
 
     //Data
-    JsonSerializer[ExaminationRegulation]
+    JsonSerializer[ExaminationRegulation],
+    JsonSerializer[ExaminationRegulationsWrapper]
   )
 }

--- a/product_code/examreg_service/impl/src/main/scala/de/upb/cs/uc4/examreg/impl/actor/ExamregHyperledgerBehaviour.scala
+++ b/product_code/examreg_service/impl/src/main/scala/de/upb/cs/uc4/examreg/impl/actor/ExamregHyperledgerBehaviour.scala
@@ -4,7 +4,8 @@ import akka.cluster.sharding.typed.scaladsl.EntityTypeKey
 import akka.pattern.StatusReply
 import com.typesafe.config.Config
 import de.upb.cs.uc4.examreg.impl.ExamregApplication
-import de.upb.cs.uc4.examreg.impl.commands.{ CloseExamregHyperledger, CreateExamregHyperledger }
+import de.upb.cs.uc4.examreg.impl.commands.{ CloseExamregHyperledger, CreateExamregHyperledger, GetAllExamregsHyperledger }
+import de.upb.cs.uc4.examreg.model.ExaminationRegulation
 import de.upb.cs.uc4.hyperledger.{ HyperledgerActorObject, HyperledgerDefaultActorFactory }
 import de.upb.cs.uc4.hyperledger.commands.{ HyperledgerBaseCommand, HyperledgerCommand }
 import de.upb.cs.uc4.hyperledger.connections.cases.{ ConnectionExaminationRegulation, ConnectionMatriculation }
@@ -29,6 +30,9 @@ class ExamregHyperledgerBehaviour(val config: Config) extends HyperledgerDefault
     * @param command which should get executed
     */
   override protected def applyCommand(connection: ConnectionExaminationRegulationTrait, command: HyperledgerCommand[_]): Unit = command match {
+
+    case GetAllExamregsHyperledger(replyTo) =>
+      replyTo ! StatusReply.success(connection.getExaminationRegulations("").fromJson[Seq[ExaminationRegulation]])
 
     case CreateExamregHyperledger(examreg, replyTo) =>
       connection.addExaminationRegulation(examreg.toJson)

--- a/product_code/examreg_service/impl/src/main/scala/de/upb/cs/uc4/examreg/impl/actor/ExamregHyperledgerBehaviour.scala
+++ b/product_code/examreg_service/impl/src/main/scala/de/upb/cs/uc4/examreg/impl/actor/ExamregHyperledgerBehaviour.scala
@@ -5,7 +5,7 @@ import akka.pattern.StatusReply
 import com.typesafe.config.Config
 import de.upb.cs.uc4.examreg.impl.ExamregApplication
 import de.upb.cs.uc4.examreg.impl.commands.{ CloseExamregHyperledger, CreateExamregHyperledger, GetAllExamregsHyperledger }
-import de.upb.cs.uc4.examreg.model.ExaminationRegulation
+import de.upb.cs.uc4.examreg.model.{ ExaminationRegulation, ExaminationRegulationsWrapper }
 import de.upb.cs.uc4.hyperledger.{ HyperledgerActorObject, HyperledgerDefaultActorFactory }
 import de.upb.cs.uc4.hyperledger.commands.{ HyperledgerBaseCommand, HyperledgerCommand }
 import de.upb.cs.uc4.hyperledger.connections.cases.{ ConnectionExaminationRegulation, ConnectionMatriculation }
@@ -32,7 +32,9 @@ class ExamregHyperledgerBehaviour(val config: Config) extends HyperledgerDefault
   override protected def applyCommand(connection: ConnectionExaminationRegulationTrait, command: HyperledgerCommand[_]): Unit = command match {
 
     case GetAllExamregsHyperledger(replyTo) =>
-      replyTo ! StatusReply.success(connection.getExaminationRegulations("").fromJson[Seq[ExaminationRegulation]])
+      replyTo ! StatusReply.success(ExaminationRegulationsWrapper(
+        connection.getExaminationRegulations("").fromJson[Seq[ExaminationRegulation]]
+      ))
 
     case CreateExamregHyperledger(examreg, replyTo) =>
       connection.addExaminationRegulation(examreg.toJson)

--- a/product_code/examreg_service/impl/src/main/scala/de/upb/cs/uc4/examreg/impl/commands/GetAllExamregsHyperledger.scala
+++ b/product_code/examreg_service/impl/src/main/scala/de/upb/cs/uc4/examreg/impl/commands/GetAllExamregsHyperledger.scala
@@ -2,7 +2,7 @@ package de.upb.cs.uc4.examreg.impl.commands
 
 import akka.actor.typed.ActorRef
 import akka.pattern.StatusReply
-import de.upb.cs.uc4.examreg.model.ExaminationRegulation
+import de.upb.cs.uc4.examreg.model.{ ExaminationRegulation, ExaminationRegulationsWrapper }
 import de.upb.cs.uc4.hyperledger.commands.HyperledgerReadCommand
 
-case class GetAllExamregsHyperledger(replyTo: ActorRef[StatusReply[Seq[ExaminationRegulation]]]) extends HyperledgerReadCommand[Seq[ExaminationRegulation]]
+case class GetAllExamregsHyperledger(replyTo: ActorRef[StatusReply[ExaminationRegulationsWrapper]]) extends HyperledgerReadCommand[ExaminationRegulationsWrapper]


### PR DESCRIPTION
### Reason for this PR
- The `GetAllExamregsHyperledger` command was never handled

### Changes in this PR
- Handle `GetAllExamregsHyperledger` in `ExamregHyperledgerBehaviour`

- [x] Changelog updated
